### PR TITLE
Upgrade Orleans packages to v9

### DIFF
--- a/src/ApiGateway/ApiGateway.csproj
+++ b/src/ApiGateway/ApiGateway.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../Grains.Abstractions/Grains.Abstractions.csproj" />
-    <PackageReference Include="Microsoft.Orleans.Client" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="9.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.57.0" />

--- a/src/Grains.Abstractions/Grains.Abstractions.csproj
+++ b/src/Grains.Abstractions/Grains.Abstractions.csproj
@@ -3,7 +3,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Client" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="9.2.1" />
     <PackageReference Include="Microsoft.Orleans.Streaming" Version="9.2.1" />
   </ItemGroup>
 </Project>

--- a/src/SiloHost/SiloHost.csproj
+++ b/src/SiloHost/SiloHost.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Streaming" Version="9.2.1" />
     <ProjectReference Include="../Grains.Abstractions/Grains.Abstractions.csproj" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="9.2.1" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- upgrade Orleans client and server packages to the 9.2.1 release across the solution
- keep streaming package aligned on version 9.2.1 for consistent Orleans dependencies

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d59b69701483268fc6d2d1ff721180