### PR TITLE
Add point-level telemetry routing and storage

### DIFF
--- a/src/Grains.Abstractions/PointGrainKey.cs
+++ b/src/Grains.Abstractions/PointGrainKey.cs
@@ -1,0 +1,27 @@
+namespace Grains.Abstractions;
+
+/// <summary>
+/// Utility methods for constructing grain keys for point grains.
+/// </summary>
+public static class PointGrainKey
+{
+    /// <summary>
+    /// Creates the storage key for a point grain using the tenant, building, space, device, and point identifiers.
+    /// </summary>
+    public static string Create(string tenantId, string buildingName, string spaceId, string deviceId, string pointId)
+    {
+        return string.Join(":", new[]
+        {
+            NormalizePart(tenantId),
+            NormalizePart(buildingName),
+            NormalizePart(spaceId),
+            NormalizePart(deviceId),
+            NormalizePart(pointId)
+        });
+    }
+
+    private static string NormalizePart(string value)
+    {
+        return (value ?? string.Empty).Replace(":", "_");
+    }
+}

--- a/src/Publisher/Program.cs
+++ b/src/Publisher/Program.cs
@@ -8,6 +8,8 @@ using RabbitMQ.Client;
 // considered production ready.
 var devices = new[] { "dev-1", "dev-2", "dev-3" };
 var tenant = Environment.GetEnvironmentVariable("TENANT") ?? "t1";
+var buildingName = Environment.GetEnvironmentVariable("BUILDING_NAME") ?? "bldg-1";
+var spaceId = Environment.GetEnvironmentVariable("SPACE_ID") ?? "floor-1/room-1";
 var rand = new Random();
 
 var factory = new ConnectionFactory
@@ -38,7 +40,9 @@ while (true)
             {
                 ["temperature"] = 20 + rand.NextDouble() * 10,
                 ["humidity"] = 50 + rand.NextDouble() * 20
-            }
+            },
+            BuildingName: buildingName,
+            SpaceId: spaceId
         );
         var body = JsonSerializer.SerializeToUtf8Bytes(msg);
         var props = channel.CreateBasicProperties();

--- a/src/SiloHost/PointGrain.cs
+++ b/src/SiloHost/PointGrain.cs
@@ -1,0 +1,68 @@
+using Grains.Abstractions;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+
+namespace SiloHost;
+
+/// <summary>
+/// Grain storing the latest telemetry for a single point. This grain holds
+/// the most recently observed value and sequence number. When updated it
+/// emits a snapshot to an Orleans stream so that the API can push changes.
+/// </summary>
+public sealed class PointGrain : Grain, IPointGrain
+{
+    private readonly IPersistentState<PointState> _state;
+    private IAsyncStream<PointSnapshot>? _stream;
+
+    public PointGrain([PersistentState("point", "PointStore")] IPersistentState<PointState> state)
+    {
+        _state = state;
+    }
+
+    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        var provider = this.GetStreamProvider("PointUpdates");
+        var streamId = StreamId.Create("PointUpdatesNs", this.GetPrimaryKeyString());
+        _stream = provider.GetStream<PointSnapshot>(streamId);
+        return Task.CompletedTask;
+    }
+
+    public async Task UpsertAsync(TelemetryPointMsg msg)
+    {
+        if (msg.Sequence <= _state.State.LastSequence)
+        {
+            return;
+        }
+
+        _state.State.LastSequence = msg.Sequence;
+        _state.State.LatestValue = msg.Value;
+        _state.State.UpdatedAt = msg.Timestamp.ToUniversalTime();
+        await _state.WriteStateAsync();
+
+        if (_stream is not null)
+        {
+            var snap = new PointSnapshot(
+                _state.State.LastSequence,
+                _state.State.LatestValue,
+                _state.State.UpdatedAt);
+            await _stream.OnNextAsync(snap);
+        }
+    }
+
+    public Task<PointSnapshot> GetAsync()
+    {
+        return Task.FromResult(new PointSnapshot(
+            _state.State.LastSequence,
+            _state.State.LatestValue,
+            _state.State.UpdatedAt));
+    }
+
+    [GenerateSerializer]
+    public sealed class PointState
+    {
+        [Id(0)] public long LastSequence { get; set; }
+        [Id(1)] public object? LatestValue { get; set; }
+        [Id(2)] public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.MinValue;
+    }
+}

--- a/src/SiloHost/Program.cs
+++ b/src/SiloHost/Program.cs
@@ -35,6 +35,8 @@ internal static class Program
             // configure grain storage
             siloBuilder.AddMemoryGrainStorage("DeviceStore");
             siloBuilder.AddMemoryStreams("DeviceUpdates");
+            siloBuilder.AddMemoryGrainStorage("PointStore");
+            siloBuilder.AddMemoryStreams("PointUpdates");
             // add stream provider for device updates
             // siloBuilder.AddSimpleMessageStreamProvider("DeviceUpdates");
             siloBuilder.AddMemoryGrainStorage("PubSubStore");


### PR DESCRIPTION
### Motivation

- Support routing and storage of telemetry at the individual point level rather than per-device to enable per-point state and streaming.
- Preserve building and space metadata from incoming payloads so points can be isolated by location.
- Split multi-point messages produced by publishers into single-point messages in the MQ consumer to simplify routing and ordering.

### Description

- Extended `TelemetryMsg` to include `BuildingName` and `SpaceId` and added a new `TelemetryPointMsg` and `PointSnapshot` DTOs for single-point payloads.
- Added `PointGrainKey` helper and a `PointGrain` implementation that persists per-point state and publishes `PointSnapshot` updates to the `PointUpdates` stream.
- Updated `MqIngestService` to deserialize `TelemetryMsg` and write one `TelemetryPointMsg` per property to the internal channel, and changed the bounded channel and batching to `TelemetryPointMsg`.
- Modified `TelemetryRouterGrain` to group and route by `(tenant, building, space, device, point)` and wired up `PointStore` and `PointUpdates` memory providers in `SiloHost` and the publisher to emit `BuildingName`/`SpaceId`.

### Testing

- No automated tests were executed as part of this change.
- Basic compile/run verification was not requested and therefore not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602d023bd4832681cd17a0356b508d)