### PR TITLE
Use long for telemetry sequence, wrap publisher counter, and align tenant env var

### DIFF
--- a/src/Grains.Abstractions/DeviceContracts.cs
+++ b/src/Grains.Abstractions/DeviceContracts.cs
@@ -23,7 +23,7 @@ public class TelemetryMsg
     /// of messages from the same device.
     /// </summary>
     [Id(1)]
-    public int Sequence { get; set; }
+    public long Sequence { get; set; }
 
     /// <summary>
     /// A dictionary of additional properties associated with the telemetry message.
@@ -74,7 +74,7 @@ public class TelemetryMsg
     {
         this.TenantId = TenantId;
         this.DeviceId = DeviceId;
-        this.Sequence = (int)Sequence;
+        this.Sequence = Sequence;
         this.Timestamp = Timestamp;
         this.Properties = Properties;
         this.BuildingName = BuildingName;
@@ -106,7 +106,7 @@ public class TelemetryPointMsg
     [Id(2)] public string SpaceId { get; set; } = string.Empty;
     [Id(3)] public string DeviceId { get; set; } = default!;
     [Id(4)] public string PointId { get; set; } = default!;
-    [Id(5)] public int Sequence { get; set; }
+    [Id(5)] public long Sequence { get; set; }
     [Id(6)] public DateTimeOffset Timestamp { get; set; }
     [Id(7)] public object? Value { get; set; }
 }

--- a/src/Publisher/Program.cs
+++ b/src/Publisher/Program.cs
@@ -7,7 +7,7 @@ using RabbitMQ.Client;
 // devices.  This app is purely for demonstration and should not be
 // considered production ready.
 var devices = new[] { "dev-1", "dev-2", "dev-3" };
-var tenant = Environment.GetEnvironmentVariable("TENANT") ?? "t1";
+var tenant = Environment.GetEnvironmentVariable("TENANT_ID") ?? "t1";
 var buildingName = Environment.GetEnvironmentVariable("BUILDING_NAME") ?? "bldg-1";
 var spaceId = Environment.GetEnvironmentVariable("SPACE_ID") ?? "floor-1/room-1";
 var rand = new Random();
@@ -30,7 +30,16 @@ while (true)
 {
     foreach (var dev in devices)
     {
-        var seq = ++seqs[dev];
+        if (seqs[dev] == long.MaxValue)
+        {
+            seqs[dev] = 0;
+        }
+        else
+        {
+            seqs[dev]++;
+        }
+
+        var seq = seqs[dev];
         var msg = new TelemetryMsg(
             TenantId: tenant,
             DeviceId: dev,


### PR DESCRIPTION
### Motivation
- Prevent sequence truncation and overflow by using 64-bit sequence values across telemetry contracts.
- Ensure the publisher uses the same tenant environment variable name as the rest of the system.
- Prevent sequence monotonicity break when the publisher counter reaches the `long` upper bound by wrapping to zero.

### Description
- Changed `TelemetryMsg.Sequence` and `TelemetryPointMsg.Sequence` from `int` to `long` in `src/Grains.Abstractions/DeviceContracts.cs` and removed the cast in the constructor so `this.Sequence = Sequence;`.
- Updated the publisher to read tenant from `TENANT_ID` instead of `TENANT` in `src/Publisher/Program.cs`.
- Implemented per-device sequence wrap-around logic in `src/Publisher/Program.cs` to set the counter to `0` when it would exceed `long.MaxValue`.

### Testing
- No automated tests were run as part of this change.
- Basic local edits were applied and committed successfully, but no build or test pipeline was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b8ead7e4832693394e082c725745)