### PR TITLE
Add Kafka telemetry ingest connector

### DIFF
--- a/src/SiloHost/Program.cs
+++ b/src/SiloHost/Program.cs
@@ -8,6 +8,7 @@ using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Streaming;
 using Telemetry.Ingest;
+using Telemetry.Ingest.Kafka;
 using Telemetry.Ingest.RabbitMq;
 using Telemetry.Ingest.Simulator;
 
@@ -29,6 +30,7 @@ internal static class Program
             var ingestSection = context.Configuration.GetSection("TelemetryIngest");
             services.AddTelemetryIngest(ingestSection);
             // Connector registration stays in code; config controls which ones are enabled.
+            services.AddKafkaIngest(ingestSection.GetSection("Kafka"));
             services.AddRabbitMqIngest(ingestSection.GetSection("RabbitMq"));
             services.AddSimulatorIngest(ingestSection.GetSection("Simulator"));
             services.AddHostedService<GraphSeedService>();

--- a/src/SiloHost/appsettings.json
+++ b/src/SiloHost/appsettings.json
@@ -3,6 +3,13 @@
     "Enabled": [ "Simulator" ],
     "BatchSize": 100,
     "ChannelCapacity": 10000,
+    "Kafka": {
+      "BootstrapServers": "localhost:9092",
+      "GroupId": "telemetry-ingest",
+      "Topic": "telemetry",
+      "EnableAutoCommit": false,
+      "AutoOffsetReset": "Latest"
+    },
     "Simulator": {
       "TenantId": "tenant",
       "BuildingName": "building",

--- a/src/Telemetry.Ingest/KafkaIngestConnector.cs
+++ b/src/Telemetry.Ingest/KafkaIngestConnector.cs
@@ -1,0 +1,188 @@
+using System.Text.Json;
+using System.Threading.Channels;
+using Confluent.Kafka;
+using Grains.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Telemetry.Ingest;
+
+namespace Telemetry.Ingest.Kafka;
+
+public sealed class KafkaIngestConnector : ITelemetryIngestConnector, IAsyncDisposable
+{
+    private readonly KafkaIngestOptions _options;
+    private readonly ILogger<KafkaIngestConnector> _logger;
+    private IConsumer<Ignore, byte[]>? _consumer;
+
+    public KafkaIngestConnector(
+        IOptions<KafkaIngestOptions> options,
+        ILogger<KafkaIngestConnector> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public string Name => "Kafka";
+
+    public async Task StartAsync(ChannelWriter<TelemetryPointMsg> writer, CancellationToken ct)
+    {
+        EnsureConsumer();
+        var topic = ResolveTopic();
+        _consumer!.Subscribe(topic);
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                ConsumeResult<Ignore, byte[]>? result;
+                try
+                {
+                    result = _consumer.Consume(ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (ConsumeException ex)
+                {
+                    _logger.LogError(ex, "Kafka consume failed.");
+                    continue;
+                }
+
+                if (result?.Message?.Value is null)
+                {
+                    _logger.LogWarning("Kafka message payload was empty.");
+                    Commit(result);
+                    continue;
+                }
+
+                TelemetryMsg? msg;
+                try
+                {
+                    msg = JsonSerializer.Deserialize<TelemetryMsg>(result.Message.Value);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to deserialize Kafka message.");
+                    Commit(result);
+                    continue;
+                }
+
+                if (msg is null)
+                {
+                    _logger.LogWarning("Kafka message deserialized to null.");
+                    Commit(result);
+                    continue;
+                }
+
+                foreach (var kv in msg.Properties)
+                {
+                    var pointMsg = new TelemetryPointMsg
+                    {
+                        TenantId = msg.TenantId,
+                        BuildingName = msg.BuildingName,
+                        SpaceId = msg.SpaceId,
+                        DeviceId = msg.DeviceId,
+                        PointId = kv.Key,
+                        Sequence = msg.Sequence,
+                        Timestamp = msg.Timestamp,
+                        Value = kv.Value
+                    };
+                    await writer.WriteAsync(pointMsg, ct);
+                }
+
+                Commit(result);
+            }
+        }
+        finally
+        {
+            _consumer?.Close();
+        }
+    }
+
+    private void EnsureConsumer()
+    {
+        if (_consumer is not null)
+        {
+            return;
+        }
+
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = ResolveBootstrapServers(),
+            GroupId = ResolveGroupId(),
+            EnableAutoCommit = _options.EnableAutoCommit,
+            AutoOffsetReset = ResolveAutoOffsetReset()
+        };
+
+        if (_options.SessionTimeoutMs.HasValue)
+        {
+            config.SessionTimeoutMs = _options.SessionTimeoutMs.Value;
+        }
+
+        if (_options.MaxPollIntervalMs.HasValue)
+        {
+            config.MaxPollIntervalMs = _options.MaxPollIntervalMs.Value;
+        }
+
+        _consumer = new ConsumerBuilder<Ignore, byte[]>(config).Build();
+    }
+
+    private string ResolveBootstrapServers()
+    {
+        return string.IsNullOrWhiteSpace(_options.BootstrapServers)
+            ? Environment.GetEnvironmentVariable("KAFKA_BOOTSTRAP_SERVERS") ?? "localhost:9092"
+            : _options.BootstrapServers;
+    }
+
+    private string ResolveGroupId()
+    {
+        return string.IsNullOrWhiteSpace(_options.GroupId)
+            ? Environment.GetEnvironmentVariable("KAFKA_GROUP_ID") ?? "telemetry-ingest"
+            : _options.GroupId;
+    }
+
+    private string ResolveTopic()
+    {
+        return string.IsNullOrWhiteSpace(_options.Topic)
+            ? Environment.GetEnvironmentVariable("KAFKA_TOPIC") ?? "telemetry"
+            : _options.Topic;
+    }
+
+    private AutoOffsetReset ResolveAutoOffsetReset()
+    {
+        var value = _options.AutoOffsetReset;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            value = Environment.GetEnvironmentVariable("KAFKA_AUTO_OFFSET_RESET") ?? "Latest";
+        }
+
+        return Enum.TryParse<AutoOffsetReset>(value, ignoreCase: true, out var result)
+            ? result
+            : AutoOffsetReset.Latest;
+    }
+
+    private void Commit(ConsumeResult<Ignore, byte[]>? result)
+    {
+        if (result is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _consumer?.Commit(result);
+        }
+        catch (KafkaException ex)
+        {
+            _logger.LogError(ex, "Kafka offset commit failed.");
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _consumer?.Dispose();
+        _consumer = null;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Telemetry.Ingest/KafkaIngestOptions.cs
+++ b/src/Telemetry.Ingest/KafkaIngestOptions.cs
@@ -1,0 +1,18 @@
+namespace Telemetry.Ingest.Kafka;
+
+public sealed class KafkaIngestOptions
+{
+    public string? BootstrapServers { get; set; }
+
+    public string? GroupId { get; set; }
+
+    public string? Topic { get; set; } = "telemetry";
+
+    public bool EnableAutoCommit { get; set; }
+
+    public string AutoOffsetReset { get; set; } = "Latest";
+
+    public int? SessionTimeoutMs { get; set; }
+
+    public int? MaxPollIntervalMs { get; set; }
+}

--- a/src/Telemetry.Ingest/KafkaServiceCollectionExtensions.cs
+++ b/src/Telemetry.Ingest/KafkaServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Telemetry.Ingest;
+
+namespace Telemetry.Ingest.Kafka;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddKafkaIngest(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<KafkaIngestOptions>(configuration);
+        services.AddSingleton<ITelemetryIngestConnector, KafkaIngestConnector>();
+        return services;
+    }
+}

--- a/src/Telemetry.Ingest/Telemetry.Ingest.csproj
+++ b/src/Telemetry.Ingest/Telemetry.Ingest.csproj
@@ -4,6 +4,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.5.0" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Add Kafka as another telemetry ingest source to match existing RabbitMQ and Simulator connectors.
- Allow configuration-driven Kafka consumer settings for flexible deployment.
- Provide a DI-registered connector so the silo can enable Kafka via configuration.

### Description
- Add `Confluent.Kafka` dependency to the `Telemetry.Ingest` project and introduce `KafkaIngestOptions` for configuration.
- Implement `KafkaIngestConnector` which consumes messages, deserializes `TelemetryMsg`, and emits `TelemetryPointMsg` into the ingest channel.
- Add `AddKafkaIngest` extension and register the connector in `SiloHost` via `services.AddKafkaIngest(...)`.
- Add sample Kafka settings to `src/SiloHost/appsettings.json` and wire up the connector in `Program.cs`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961845edaf48326b3e3c475063911eb)