### PR TITLE
Add control interface contracts and documentation

### DIFF
--- a/src/ApiGateway/Contracts/PointControlContracts.cs
+++ b/src/ApiGateway/Contracts/PointControlContracts.cs
@@ -1,0 +1,20 @@
+namespace ApiGateway.Contracts;
+
+public sealed record PointControlRequest(
+    string CommandId,
+    string BuildingName,
+    string SpaceId,
+    string DeviceId,
+    string PointId,
+    object? DesiredValue,
+    Dictionary<string, string>? Metadata);
+
+public sealed record PointControlResponse(
+    string CommandId,
+    string Status,
+    DateTimeOffset RequestedAt,
+    DateTimeOffset? AcceptedAt,
+    DateTimeOffset? AppliedAt,
+    string? ConnectorName,
+    string? CorrelationId,
+    string? LastError);

--- a/src/Grains.Abstractions/ControlContracts.cs
+++ b/src/Grains.Abstractions/ControlContracts.cs
@@ -1,0 +1,45 @@
+using Orleans;
+
+namespace Grains.Abstractions;
+
+public enum ControlRequestStatus
+{
+    Pending = 0,
+    Accepted = 1,
+    Applied = 2,
+    Rejected = 3,
+    Failed = 4,
+    Timeout = 5
+}
+
+[GenerateSerializer]
+public sealed class PointControlRequest
+{
+    [Id(0)] public string CommandId { get; set; } = string.Empty;
+    [Id(1)] public string TenantId { get; set; } = string.Empty;
+    [Id(2)] public string BuildingName { get; set; } = string.Empty;
+    [Id(3)] public string SpaceId { get; set; } = string.Empty;
+    [Id(4)] public string DeviceId { get; set; } = string.Empty;
+    [Id(5)] public string PointId { get; set; } = string.Empty;
+    [Id(6)] public object? DesiredValue { get; set; }
+    [Id(7)] public DateTimeOffset RequestedAt { get; set; } = DateTimeOffset.UtcNow;
+    [Id(8)] public Dictionary<string, string> Metadata { get; set; } = new();
+}
+
+[GenerateSerializer]
+public sealed record PointControlSnapshot(
+    string CommandId,
+    ControlRequestStatus Status,
+    object? DesiredValue,
+    DateTimeOffset RequestedAt,
+    DateTimeOffset? AcceptedAt,
+    DateTimeOffset? AppliedAt,
+    string? ConnectorName,
+    string? CorrelationId,
+    string? LastError);
+
+public interface IPointControlGrain : IGrainWithStringKey
+{
+    Task<PointControlSnapshot> SubmitAsync(PointControlRequest request);
+    Task<PointControlSnapshot?> GetAsync(string commandId);
+}

--- a/src/Telemetry.Ingest/ControlEgressContracts.cs
+++ b/src/Telemetry.Ingest/ControlEgressContracts.cs
@@ -1,0 +1,38 @@
+namespace Telemetry.Ingest;
+
+public enum ControlConfirmMode
+{
+    AckOnly = 0,
+    TelemetryConfirm = 1,
+    ReadBackConfirm = 2
+}
+
+public sealed class ControlEgressRequest
+{
+    public string CommandId { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string BuildingName { get; set; } = string.Empty;
+    public string SpaceId { get; set; } = string.Empty;
+    public string DeviceId { get; set; } = string.Empty;
+    public string PointId { get; set; } = string.Empty;
+    public object? DesiredValue { get; set; }
+    public DateTimeOffset RequestedAt { get; set; } = DateTimeOffset.UtcNow;
+    public Dictionary<string, string> Metadata { get; set; } = new();
+}
+
+public sealed class ControlEgressResult
+{
+    public string CommandId { get; set; } = string.Empty;
+    public string ConnectorName { get; set; } = string.Empty;
+    public bool Accepted { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? Error { get; set; }
+    public ControlConfirmMode ConfirmMode { get; set; }
+}
+
+public interface IControlEgressConnector
+{
+    string Name { get; }
+    ControlConfirmMode ConfirmMode { get; }
+    Task<ControlEgressResult> SendAsync(ControlEgressRequest request, CancellationToken ct);
+}


### PR DESCRIPTION
### Motivation

- Introduce a control flow model to issue commands to writable points and track their lifecycle through grains and egress connectors.
- Provide a minimal, connector‑agnostic API surface so different egress implementations can express distinct acknowledgement/confirmation semantics.
- Surface API request/response contracts so the gateway can accept and report control command statuses.

### Description

- Add `src/Grains.Abstractions/ControlContracts.cs` defining `ControlRequestStatus`, a serializable `PointControlRequest`, `PointControlSnapshot`, and the grain interface `IPointControlGrain` with `SubmitAsync` and `GetAsync` methods.
- Add `src/Telemetry.Ingest/ControlEgressContracts.cs` defining `ControlConfirmMode`, `ControlEgressRequest`, `ControlEgressResult`, and the `IControlEgressConnector` interface with `SendAsync` and connector metadata (`Name`, `ConfirmMode`).
- Add `src/ApiGateway/Contracts/PointControlContracts.cs` with API contract records `PointControlRequest` and `PointControlResponse` to represent incoming requests and status responses.
- Update `README.md` to document the planned REST endpoints, the grain interface, the egress connector contract, and a control sequence diagram showing the lifecycle from submission to final confirmation.

### Testing

- No automated tests were executed as part of this change.
- The patch only adds interfaces and documentation and does not modify runtime logic or existing tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618bc9b414832689e6c3bae2dd51a0)