### PR TITLE
Add telemetry event sink pipeline

### DIFF
--- a/src/SiloHost/Program.cs
+++ b/src/SiloHost/Program.cs
@@ -33,6 +33,7 @@ internal static class Program
             services.AddKafkaIngest(ingestSection.GetSection("Kafka"));
             services.AddRabbitMqIngest(ingestSection.GetSection("RabbitMq"));
             services.AddSimulatorIngest(ingestSection.GetSection("Simulator"));
+            services.AddLoggingTelemetryEventSink();
             services.AddHostedService<GraphSeedService>();
         });
         builder.UseOrleans(siloBuilder =>

--- a/src/SiloHost/appsettings.json
+++ b/src/SiloHost/appsettings.json
@@ -3,6 +3,9 @@
     "Enabled": [ "Simulator" ],
     "BatchSize": 100,
     "ChannelCapacity": 10000,
+    "EventSinks": {
+      "Enabled": [ "Logging" ]
+    },
     "Kafka": {
       "BootstrapServers": "localhost:9092",
       "GroupId": "telemetry-ingest",

--- a/src/Telemetry.Ingest/EventEnvelope.cs
+++ b/src/Telemetry.Ingest/EventEnvelope.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+
+namespace Telemetry.Ingest;
+
+public enum TelemetryEventType
+{
+    Telemetry = 0,
+    Log = 1,
+    Control = 2
+}
+
+public enum TelemetryLogSeverity
+{
+    Trace = 0,
+    Debug = 1,
+    Information = 2,
+    Warning = 3,
+    Error = 4,
+    Critical = 5
+}
+
+public sealed record TelemetryEventEnvelope(
+    string TenantId,
+    string BuildingName,
+    string SpaceId,
+    string DeviceId,
+    string PointId,
+    long Sequence,
+    DateTimeOffset OccurredAt,
+    DateTimeOffset IngestedAt,
+    TelemetryEventType EventType,
+    TelemetryLogSeverity? Severity,
+    object? Value,
+    JsonDocument? Payload,
+    IReadOnlyDictionary<string, string>? Tags);

--- a/src/Telemetry.Ingest/ITelemetryEventSink.cs
+++ b/src/Telemetry.Ingest/ITelemetryEventSink.cs
@@ -1,0 +1,10 @@
+namespace Telemetry.Ingest;
+
+public interface ITelemetryEventSink
+{
+    string Name { get; }
+
+    Task WriteAsync(TelemetryEventEnvelope envelope, CancellationToken ct);
+
+    Task WriteBatchAsync(IReadOnlyList<TelemetryEventEnvelope> batch, CancellationToken ct);
+}

--- a/src/Telemetry.Ingest/LoggingTelemetryEventSink.cs
+++ b/src/Telemetry.Ingest/LoggingTelemetryEventSink.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Logging;
+
+namespace Telemetry.Ingest;
+
+public sealed class LoggingTelemetryEventSink : ITelemetryEventSink
+{
+    private readonly ILogger<LoggingTelemetryEventSink> _logger;
+
+    public LoggingTelemetryEventSink(ILogger<LoggingTelemetryEventSink> logger)
+    {
+        _logger = logger;
+    }
+
+    public string Name => "Logging";
+
+    public Task WriteAsync(TelemetryEventEnvelope envelope, CancellationToken ct)
+    {
+        return WriteBatchAsync(new[] { envelope }, ct);
+    }
+
+    public Task WriteBatchAsync(IReadOnlyList<TelemetryEventEnvelope> batch, CancellationToken ct)
+    {
+        if (batch.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        var first = batch[0];
+        _logger.LogInformation(
+            "Telemetry event batch {Count} for tenant {TenantId} device {DeviceId}.",
+            batch.Count,
+            first.TenantId,
+            first.DeviceId);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Telemetry.Ingest/TelemetryEventEnvelopeFactory.cs
+++ b/src/Telemetry.Ingest/TelemetryEventEnvelopeFactory.cs
@@ -1,0 +1,26 @@
+using Grains.Abstractions;
+
+namespace Telemetry.Ingest;
+
+public static class TelemetryEventEnvelopeFactory
+{
+    public static TelemetryEventEnvelope FromTelemetryPoint(
+        TelemetryPointMsg msg,
+        DateTimeOffset ingestedAt)
+    {
+        return new TelemetryEventEnvelope(
+            msg.TenantId,
+            msg.BuildingName,
+            msg.SpaceId,
+            msg.DeviceId,
+            msg.PointId,
+            msg.Sequence,
+            msg.Timestamp,
+            ingestedAt,
+            TelemetryEventType.Telemetry,
+            null,
+            msg.Value,
+            null,
+            null);
+    }
+}

--- a/src/Telemetry.Ingest/TelemetryEventSinkServiceCollectionExtensions.cs
+++ b/src/Telemetry.Ingest/TelemetryEventSinkServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Telemetry.Ingest;
+
+public static class TelemetryEventSinkServiceCollectionExtensions
+{
+    public static IServiceCollection AddLoggingTelemetryEventSink(this IServiceCollection services)
+    {
+        services.AddSingleton<ITelemetryEventSink, LoggingTelemetryEventSink>();
+        return services;
+    }
+}

--- a/src/Telemetry.Ingest/TelemetryIngestCoordinator.cs
+++ b/src/Telemetry.Ingest/TelemetryIngestCoordinator.cs
@@ -13,14 +13,18 @@ public sealed class TelemetryIngestCoordinator : BackgroundService
     private readonly TelemetryIngestOptions _options;
     private readonly ILogger<TelemetryIngestCoordinator> _logger;
     private readonly Channel<TelemetryPointMsg> _channel;
+    private readonly IReadOnlyList<ITelemetryEventSink> _eventSinks;
+    private IReadOnlyList<ITelemetryEventSink> _activeEventSinks = Array.Empty<ITelemetryEventSink>();
 
     public TelemetryIngestCoordinator(
         IEnumerable<ITelemetryIngestConnector> connectors,
+        IEnumerable<ITelemetryEventSink> eventSinks,
         ITelemetryRouterGrain router,
         IOptions<TelemetryIngestOptions> options,
         ILogger<TelemetryIngestCoordinator> logger)
     {
         _connectors = connectors.ToList();
+        _eventSinks = eventSinks.ToList();
         _router = router;
         _options = options.Value;
         _logger = logger;
@@ -33,6 +37,12 @@ public sealed class TelemetryIngestCoordinator : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        _activeEventSinks = ResolveActiveSinks();
+        if (_activeEventSinks.Count == 0)
+        {
+            _logger.LogInformation("No telemetry event sinks enabled.");
+        }
+
         var enabled = _options.Enabled ?? Array.Empty<string>();
         var enabledSet = new HashSet<string>(enabled, StringComparer.OrdinalIgnoreCase);
         var activeConnectors = enabledSet.Count == 0
@@ -93,12 +103,14 @@ public sealed class TelemetryIngestCoordinator : BackgroundService
                     }
 
                     await _router.RouteBatchAsync(batch.ToArray());
+                    await WriteToSinksAsync(batch, ct);
                     batch.Clear();
                 }
 
                 if (batch.Count > 0)
                 {
                     await _router.RouteBatchAsync(batch.ToArray());
+                    await WriteToSinksAsync(batch, ct);
                     batch.Clear();
                 }
             }
@@ -111,8 +123,62 @@ public sealed class TelemetryIngestCoordinator : BackgroundService
             if (batch.Count > 0)
             {
                 await _router.RouteBatchAsync(batch.ToArray());
+                await WriteToSinksAsync(batch, ct);
                 batch.Clear();
             }
+        }
+    }
+
+    private IReadOnlyList<ITelemetryEventSink> ResolveActiveSinks()
+    {
+        if (_eventSinks.Count == 0)
+        {
+            return Array.Empty<ITelemetryEventSink>();
+        }
+
+        var enabled = _options.EventSinks.Enabled ?? Array.Empty<string>();
+        if (enabled.Length == 0)
+        {
+            return _eventSinks;
+        }
+
+        var enabledSet = new HashSet<string>(enabled, StringComparer.OrdinalIgnoreCase);
+        return _eventSinks.Where(sink => enabledSet.Contains(sink.Name)).ToList();
+    }
+
+    private async Task WriteToSinksAsync(IReadOnlyList<TelemetryPointMsg> batch, CancellationToken ct)
+    {
+        if (_activeEventSinks.Count == 0 || batch.Count == 0)
+        {
+            return;
+        }
+
+        var ingestedAt = DateTimeOffset.UtcNow;
+        var envelopes = new List<TelemetryEventEnvelope>(batch.Count);
+        foreach (var msg in batch)
+        {
+            envelopes.Add(TelemetryEventEnvelopeFactory.FromTelemetryPoint(msg, ingestedAt));
+        }
+
+        var tasks = _activeEventSinks.Select(sink => WriteBatchSafeAsync(sink, envelopes, ct));
+        await Task.WhenAll(tasks);
+    }
+
+    private async Task WriteBatchSafeAsync(
+        ITelemetryEventSink sink,
+        IReadOnlyList<TelemetryEventEnvelope> batch,
+        CancellationToken ct)
+    {
+        try
+        {
+            await sink.WriteBatchAsync(batch, ct);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Telemetry event sink {SinkName} failed.", sink.Name);
         }
     }
 }

--- a/src/Telemetry.Ingest/TelemetryIngestOptions.cs
+++ b/src/Telemetry.Ingest/TelemetryIngestOptions.cs
@@ -4,7 +4,14 @@ public sealed class TelemetryIngestOptions
 {
     public string[]? Enabled { get; set; }
 
+    public TelemetryIngestEventSinkOptions EventSinks { get; set; } = new();
+
     public int ChannelCapacity { get; set; } = 10000;
 
     public int BatchSize { get; set; } = 100;
+}
+
+public sealed class TelemetryIngestEventSinkOptions
+{
+    public string[]? Enabled { get; set; }
 }


### PR DESCRIPTION
### Motivation

- Provide a pluggable pipeline to export ingested telemetry events to external sinks (e.g., logging, storage) for downstream processing.
- Emit a richer event envelope including metadata and event types to support multiple sink targets and future extensions.
- Allow runtime control of which ingest connectors and event sinks are active through the `TelemetryIngest` configuration.

### Description

- Added `TelemetryEventEnvelope`, `TelemetryEventType`, and `TelemetryLogSeverity` enums and the `TelemetryEventEnvelopeFactory` to build envelopes from `TelemetryPointMsg`.
- Introduced `ITelemetryEventSink` with `WriteAsync`/`WriteBatchAsync` and implemented `LoggingTelemetryEventSink` plus `AddLoggingTelemetryEventSink` service registration.
- Extended `TelemetryIngestOptions` with `EventSinks` options and updated `TelemetryIngestCoordinator` to accept `IEnumerable<ITelemetryEventSink>`, resolve enabled sinks, convert batches to envelopes, and write to sinks with isolated error handling.
- Registered the logging sink in `SiloHost` and added a sample `EventSinks` section to `appsettings.json` to enable the `Logging` sink.

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696197187a38832689df3fca0c4dcdaf)