### PR TITLE
Switch RDF parsing from GUTP to SBCO prefixes

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -4,7 +4,7 @@
 
 ## プロジェクト概要
 
-**目的**: GUTPプロトコルに基づく建物・設備・センサーデータのRDFファイルを解析し、Orleansクラスターで利用可能な形式に変換する。
+**目的**: SBCO オントロジーに基づく建物・設備・センサーデータのRDFファイルを解析し、Orleansクラスターで利用可能な形式に変換する。
 
 **主要機能**:
 - Turtle / N-Triples / JSON-LD / RDF/XML などのRDFファイル解析
@@ -72,7 +72,7 @@ foreach (var device in deviceData.Devices)
 
 ### 入力
 - Turtle / N-Triples / JSON-LD / RDF/XML / TriG / TriX / N-Quads 形式のRDFファイル
-- GUTPプロトコル準拠のデータ構造
+- SBCO オントロジー準拠のデータ構造
 - REC (Real Estate Core) オントロジー
 
 ### 出力

--- a/src/DataModel.Analyzer/README.md
+++ b/src/DataModel.Analyzer/README.md
@@ -1,6 +1,6 @@
 # DataModel.Analyzer
 
-Turtle・N-Triples・JSON-LD・RDF/XML など複数形式のRDFデータを解析し、建物データモデルとして構造化するライブラリです。GUTPプロトコルに基づく建物・設備・センサーデータの解析とエクスポート機能を提供します。
+Turtle・N-Triples・JSON-LD・RDF/XML など複数形式のRDFデータを解析し、建物データモデルとして構造化するライブラリです。SBCO オントロジーに基づく建物・設備・センサーデータの解析とエクスポート機能を提供します。
 
 ## 機能
 
@@ -87,24 +87,24 @@ if (result.IsSuccess)
 - `rec:identifiers` - 識別子
 - `dct:identifier` - DTIDなどの識別子
 
-### GUTP機器プロパティ
-- `gutp:gateway_id` - ゲートウェイID  
-- `gutp:device_id` - デバイスID
-- `gutp:device_type` - デバイスタイプ
-- `gutp:supplier` - 供給者
-- `gutp:owner` - 所有者
+### SBCO機器プロパティ
+- `sbco:gateway_id` - ゲートウェイID  
+- `sbco:device_id` - デバイスID
+- `sbco:device_type` - デバイスタイプ
+- `sbco:supplier` - 供給者
+- `sbco:owner` - 所有者
 
-### GUTPポイントプロパティ
-- `gutp:point_id` - ポイントID
-- `gutp:point_type` - ポイントタイプ（Temperature, CO2, Humidityなど）
-- `gutp:point_specification` - ポイント仕様（Measurement, Command, Alarmなど）
-- `gutp:local_id` - ローカルID
-- `gutp:writable` - 書き込み可能フラグ
-- `gutp:interval` - 測定間隔
-- `gutp:unit` - 単位
-- `gutp:max_pres_value` - 最大値
-- `gutp:min_pres_value` - 最小値
-- `gutp:scale` - スケール値
+### SBCOポイントプロパティ
+- `sbco:point_id` - ポイントID
+- `sbco:point_type` - ポイントタイプ（Temperature, CO2, Humidityなど）
+- `sbco:point_specification` - ポイント仕様（Measurement, Command, Alarmなど）
+- `sbco:local_id` - ローカルID
+- `sbco:writable` - 書き込み可能フラグ
+- `sbco:interval` - 測定間隔
+- `sbco:unit` - 単位
+- `sbco:max_pres_value` - 最大値
+- `sbco:min_pres_value` - 最小値
+- `sbco:scale` - スケール値
 
 ## 出力形式
 

--- a/src/DataModel.Analyzer/Services/RdfAnalyzerService.cs
+++ b/src/DataModel.Analyzer/Services/RdfAnalyzerService.cs
@@ -27,7 +27,6 @@ public class RdfAnalyzerService
     private readonly string _schemaFolder;
 
     private const string RecNamespace = "https://w3id.org/rec/";
-    private const string GutpNamespace = "https://www.gutp.jp/bim-wg#";
     private const string SbcoNamespace = "https://www.sbco.or.jp/ont/";
     private const string BrickNamespace = "https://brickschema.org/schema/Brick#";
     private const string DctNamespace = "http://purl.org/dc/terms/";
@@ -398,7 +397,7 @@ public class RdfAnalyzerService
             var levelNumberValue = GetFirstLiteralValue(
                 graph,
                 subject,
-                new[] { $"{SbcoNamespace}levelNumber", $"{GutpNamespace}levelNumber", $"{RecNamespace}levelNumber" });
+                new[] { $"{SbcoNamespace}levelNumber", $"{RecNamespace}levelNumber" });
 
             if (!string.IsNullOrWhiteSpace(levelNumberValue) && int.TryParse(levelNumberValue, out var levelNumber))
             {
@@ -443,7 +442,7 @@ public class RdfAnalyzerService
     private List<Equipment> ExtractEquipment(IGraph graph)
     {
         var equipmentList = new List<Equipment>();
-        var subjects = GetSubjectsOfType(graph, new[] { $"{SbcoNamespace}EquipmentExt", $"{SbcoNamespace}Equipment", $"{GutpNamespace}GUTPEquipment" });
+        var subjects = GetSubjectsOfType(graph, new[] { $"{SbcoNamespace}EquipmentExt", $"{SbcoNamespace}Equipment" });
 
         foreach (var subject in subjects)
         {
@@ -474,7 +473,7 @@ public class RdfAnalyzerService
     private List<Point> ExtractPoints(IGraph graph)
     {
         var points = new List<Point>();
-        var subjects = GetSubjectsOfType(graph, new[] { $"{SbcoNamespace}PointExt", $"{SbcoNamespace}Point", $"{GutpNamespace}GUTPPoint" });
+        var subjects = GetSubjectsOfType(graph, new[] { $"{SbcoNamespace}PointExt", $"{SbcoNamespace}Point" });
 
         foreach (var subject in subjects)
         {
@@ -632,11 +631,11 @@ public class RdfAnalyzerService
     {
         var properties = new Dictionary<string, string>
         {
-            { $"{GutpNamespace}gateway_id", nameof(Equipment.GatewayId) },
-            { $"{GutpNamespace}device_id", nameof(Equipment.DeviceId) },
-            { $"{GutpNamespace}device_type", nameof(Equipment.DeviceType) },
-            { $"{GutpNamespace}supplier", nameof(Equipment.Supplier) },
-            { $"{GutpNamespace}owner", nameof(Equipment.Owner) }
+            { $"{SbcoNamespace}gateway_id", nameof(Equipment.GatewayId) },
+            { $"{SbcoNamespace}device_id", nameof(Equipment.DeviceId) },
+            { $"{SbcoNamespace}device_type", nameof(Equipment.DeviceType) },
+            { $"{SbcoNamespace}supplier", nameof(Equipment.Supplier) },
+            { $"{SbcoNamespace}owner", nameof(Equipment.Owner) }
         };
 
         foreach (var (predicateUri, propertyName) in properties)
@@ -654,14 +653,14 @@ public class RdfAnalyzerService
     {
         var stringProperties = new Dictionary<string, string>
         {
-            { $"{GutpNamespace}point_id", nameof(Point.PointId) },
-            { $"{GutpNamespace}point_type", nameof(Point.PointType) },
-            { $"{GutpNamespace}point_specification", nameof(Point.PointSpecification) },
-            { $"{GutpNamespace}local_id", nameof(Point.LocalId) },
-            { $"{GutpNamespace}unit", nameof(Point.Unit) },
-            { $"{GutpNamespace}device_id_bacnet", nameof(Point.DeviceIdBacnet) },
-            { $"{GutpNamespace}instance_no_bacnet", nameof(Point.InstanceNoBacnet) },
-            { $"{GutpNamespace}object_type_bacnet", nameof(Point.ObjectTypeBacnet) },
+            { $"{SbcoNamespace}point_id", nameof(Point.PointId) },
+            { $"{SbcoNamespace}point_type", nameof(Point.PointType) },
+            { $"{SbcoNamespace}point_specification", nameof(Point.PointSpecification) },
+            { $"{SbcoNamespace}local_id", nameof(Point.LocalId) },
+            { $"{SbcoNamespace}unit", nameof(Point.Unit) },
+            { $"{SbcoNamespace}device_id_bacnet", nameof(Point.DeviceIdBacnet) },
+            { $"{SbcoNamespace}instance_no_bacnet", nameof(Point.InstanceNoBacnet) },
+            { $"{SbcoNamespace}object_type_bacnet", nameof(Point.ObjectTypeBacnet) },
             { $"{SbcoNamespace}pointType", nameof(Point.PointType) },
             { $"{SbcoNamespace}pointSpecification", nameof(Point.PointSpecification) },
             { $"{SbcoNamespace}unit", nameof(Point.Unit) }
@@ -677,16 +676,16 @@ public class RdfAnalyzerService
             }
         }
 
-        var writableValue = GetFirstLiteralValue(graph, subject, new[] { $"{GutpNamespace}writable" });
+        var writableValue = GetFirstLiteralValue(graph, subject, new[] { $"{SbcoNamespace}writable" });
         if (!string.IsNullOrWhiteSpace(writableValue) && bool.TryParse(writableValue, out var writable))
         {
             point.Writable = writable;
         }
 
-        ExtractNumericProperty(graph, subject, new[] { $"{GutpNamespace}interval", $"{SbcoNamespace}intervalCapability" }, value => point.Interval = (int?)value);
-        ExtractNumericProperty(graph, subject, new[] { $"{GutpNamespace}max_pres_value", $"{SbcoNamespace}maxPresValue" }, value => point.MaxPresValue = value);
-        ExtractNumericProperty(graph, subject, new[] { $"{GutpNamespace}min_pres_value", $"{SbcoNamespace}minPresValue" }, value => point.MinPresValue = value);
-        ExtractNumericProperty(graph, subject, new[] { $"{GutpNamespace}scale", $"{SbcoNamespace}scale" }, value => point.Scale = value);
+        ExtractNumericProperty(graph, subject, new[] { $"{SbcoNamespace}interval", $"{SbcoNamespace}intervalCapability" }, value => point.Interval = (int?)value);
+        ExtractNumericProperty(graph, subject, new[] { $"{SbcoNamespace}max_pres_value", $"{SbcoNamespace}maxPresValue" }, value => point.MaxPresValue = value);
+        ExtractNumericProperty(graph, subject, new[] { $"{SbcoNamespace}min_pres_value", $"{SbcoNamespace}minPresValue" }, value => point.MinPresValue = value);
+        ExtractNumericProperty(graph, subject, new[] { $"{SbcoNamespace}scale", $"{SbcoNamespace}scale" }, value => point.Scale = value);
 
         point.HasQuantity = GetFirstObjectValue(graph, subject, new[] { $"{SbcoNamespace}hasQuantity", $"{BrickNamespace}hasQuantity" });
         point.HasSubstance = GetFirstObjectValue(graph, subject, new[] { $"{SbcoNamespace}hasSubstance", $"{BrickNamespace}hasSubstance" });
@@ -809,4 +808,3 @@ public class RdfAnalyzerService
         }
     }
 }
-


### PR DESCRIPTION
### Motivation
- The codebase contained leftover GUTP-prefixed predicates and class checks but the project should use the SBCO ontology for equipment/point properties.
- Mappings and type detection needed to be aligned to `SbcoNamespace` so RDF parsing extracts properties consistently from SBCO data.
- Documentation still referenced GUTP which would confuse users and must reflect the SBCO change.

### Description
- Removed the `GutpNamespace` usage in `src/DataModel.Analyzer/Services/RdfAnalyzerService.cs` and updated type lookups to stop checking GUTP classes and use SBCO classes in calls to `GetSubjectsOfType`.
- Replaced GUTP predicate mappings with `SbcoNamespace` equivalents in `ExtractGutpEquipmentProperties` and `ExtractPointProperties`, and switched numeric/writable extraction to use SBCO predicates (e.g. interval, max/min values, `writable`).
- Deleted the unused `GutpNamespace` constant from `RdfAnalyzerService` and updated property accessors to read values via the SBCO predicates with `GetFirstLiteralValue`/`GetFirstObjectValue`.
- Updated documentation files `src/DataModel.Analyzer/README.md` and `PROJECT_OVERVIEW.md` to reference the SBCO ontology and `sbco:` property names instead of GUTP.

### Testing
- No automated tests were executed as part of this change.
- Local static inspection and repository searches were performed to confirm occurrences of `gutp` were removed or replaced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961adba09b08326bac064245411cc25)