### PR TITLE
Add point binding attributes for node value lookup

### DIFF
--- a/src/DataModel.Analyzer.Tests/OrleansIntegrationServiceBindingTests.cs
+++ b/src/DataModel.Analyzer.Tests/OrleansIntegrationServiceBindingTests.cs
@@ -1,0 +1,89 @@
+using DataModel.Analyzer.Integration;
+using DataModel.Analyzer.Models;
+using DataModel.Analyzer.Services;
+using FluentAssertions;
+using Grains.Abstractions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace DataModel.Analyzer.Tests;
+
+public class OrleansIntegrationServiceBindingTests
+{
+    [Fact]
+    public void CreateGraphSeedData_AddsPointBindingAttributes()
+    {
+        var model = BuildModel();
+        var service = CreateService();
+
+        var seed = service.CreateGraphSeedData(model);
+
+        var pointNode = seed.Nodes.Single(node => node.NodeType == GraphNodeType.Point && node.NodeId == "point:1");
+        pointNode.Attributes["PointId"].Should().Be("temp-1");
+        pointNode.Attributes["DeviceId"].Should().Be("dev-1");
+        pointNode.Attributes["BuildingName"].Should().Be("BuildingA");
+        pointNode.Attributes["SpaceId"].Should().Be("Room101");
+
+        var grainKey = PointGrainKey.Create(
+            "tenantA",
+            pointNode.Attributes["BuildingName"],
+            pointNode.Attributes["SpaceId"],
+            pointNode.Attributes["DeviceId"],
+            pointNode.Attributes["PointId"]);
+        grainKey.Should().Be("tenantA:BuildingA:Room101:dev-1:temp-1");
+    }
+
+    private static BuildingDataModel BuildModel()
+    {
+        var site = new Site { Name = "SiteA", Uri = "site:1" };
+        var building = new Building { Name = "BuildingA", Uri = "building:1", SiteUri = site.Uri };
+        var level = new Level { Name = "L1", Uri = "level:1", BuildingUri = building.Uri };
+        var area = new Area { Name = "Room101", Uri = "area:1", LevelUri = level.Uri };
+        var equipment = new Equipment
+        {
+            Name = "AHU",
+            Uri = "equip:1",
+            DeviceId = "dev-1",
+            DeviceType = "HVAC",
+            GatewayId = "gw-1",
+            AreaUri = area.Uri
+        };
+        var point = new Point
+        {
+            Name = "Temperature",
+            Uri = "point:1",
+            PointId = "temp-1",
+            PointType = "temperature",
+            EquipmentUri = equipment.Uri
+        };
+
+        site.Buildings.Add(building);
+        building.Levels.Add(level);
+        level.Areas.Add(area);
+        area.Equipment.Add(equipment);
+        equipment.Points.Add(point);
+
+        return new BuildingDataModel
+        {
+            Sites = { site },
+            Buildings = { building },
+            Levels = { level },
+            Areas = { area },
+            Equipment = { equipment },
+            Points = { point }
+        };
+    }
+
+    private static OrleansIntegrationService CreateService()
+    {
+        var rdfAnalyzer = new RdfAnalyzerService(
+            NullLogger<RdfAnalyzerService>.Instance,
+            Options.Create(new RdfAnalyzerOptions()));
+        var exportService = new DataModelExportService(NullLogger<DataModelExportService>.Instance);
+        var analyzer = new DataModelAnalyzer(
+            rdfAnalyzer,
+            exportService,
+            NullLogger<DataModelAnalyzer>.Instance);
+        return new OrleansIntegrationService(analyzer, NullLogger<OrleansIntegrationService>.Instance);
+    }
+}


### PR DESCRIPTION
### Motivation
- Enable resolving point values from graph nodes by binding point metadata (device/building/space) to point graph nodes for downstream `PointGrain` lookups.
- Ensure the graph seed includes attributes necessary for routing value requests to the correct device/point grain.
- Provide a unit test to verify attribute population and grain key construction for routed value lookups.

### Description
- Added `AddPointBindingAttributes` to `OrleansIntegrationService` and call it when creating point node definitions to populate `DeviceId`, `SpaceId`, and `BuildingName` attributes. 
- Implemented helper resolvers `ResolveEquipmentForPoint`, `ResolveAreaForEquipment`, and `ResolveBuildingForArea` to infer bindings from the `BuildingDataModel` relationships.
- Updated the API gateway `/api/nodes/{nodeId}/value` endpoint in `Program.cs` to fetch the graph node via `IGraphNodeGrain`, read the binding attributes, build a `PointGrainKey` with `PointGrainKey.Create(...)` and return the `IPointGrain` snapshot.
- Added unit tests in `src/DataModel.Analyzer.Tests/OrleansIntegrationServiceBindingTests.cs` to validate attributes are set and the produced grain key matches the expected format.

### Testing
- Added unit test `OrleansIntegrationServiceBindingTests` to exercise `CreateGraphSeedData` and binding attribute population (test included in the test project).
- Attempted to run `dotnet test src/DataModel.Analyzer.Tests/DataModel.Analyzer.Tests.csproj` but the execution environment does not have the `dotnet` CLI available, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961adb6f6a483268161568c449dbf28)