### PR TITLE
Add RabbitMQ load test stages, connector instrumentation, and publisher burst mode

### DIFF
--- a/src/Publisher/Program.cs
+++ b/src/Publisher/Program.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 using Grains.Abstractions;
 using RabbitMQ.Client;
@@ -6,7 +5,25 @@ using RabbitMQ.Client;
 // Publisher sends random telemetry messages periodically for a few
 // devices.  This app is purely for demonstration and should not be
 // considered production ready.
-var devices = new[] { "dev-1", "dev-2", "dev-3" };
+var deviceCount = GetIntArgValue(args, "--device-count")
+    ?? GetIntEnvValue("DEVICE_COUNT")
+    ?? 3;
+var baseIntervalMs = GetIntArgValue(args, "--interval-ms")
+    ?? GetIntEnvValue("PUBLISH_INTERVAL_MS")
+    ?? 500;
+var burstEnabled = args.Contains("--burst", StringComparer.OrdinalIgnoreCase)
+    || GetBoolEnvValue("BURST_ENABLED");
+var burstIntervalMs = GetIntArgValue(args, "--burst-interval-ms")
+    ?? GetIntEnvValue("BURST_INTERVAL_MS")
+    ?? 5;
+var burstDurationSeconds = GetIntArgValue(args, "--burst-duration-sec")
+    ?? GetIntEnvValue("BURST_DURATION_SEC")
+    ?? 10;
+var burstPauseSeconds = GetIntArgValue(args, "--burst-pause-sec")
+    ?? GetIntEnvValue("BURST_PAUSE_SEC")
+    ?? 20;
+
+var devices = Enumerable.Range(1, Math.Max(1, deviceCount)).Select(i => $"dev-{i}").ToArray();
 var tenant = Environment.GetEnvironmentVariable("TENANT_ID") ?? "t1";
 var buildingName = Environment.GetEnvironmentVariable("BUILDING_NAME") ?? "bldg-1";
 var spaceId = Environment.GetEnvironmentVariable("SPACE_ID") ?? "floor-1/room-1";
@@ -26,8 +43,22 @@ channel.QueueDeclare(queue: "telemetry", durable: false, exclusive: false, autoD
 var seqs = new Dictionary<string, long>();
 foreach (var d in devices) seqs[d] = 0;
 
+var useBurst = burstEnabled && burstIntervalMs > 0;
+var baseInterval = TimeSpan.FromMilliseconds(Math.Max(1, baseIntervalMs));
+var burstInterval = TimeSpan.FromMilliseconds(Math.Max(1, burstIntervalMs));
+var burstDuration = TimeSpan.FromSeconds(Math.Max(1, burstDurationSeconds));
+var burstPause = TimeSpan.FromSeconds(Math.Max(1, burstPauseSeconds));
+var nextBurstSwitch = DateTimeOffset.UtcNow + burstPause;
+var inBurst = false;
+
 while (true)
 {
+    if (useBurst && DateTimeOffset.UtcNow >= nextBurstSwitch)
+    {
+        inBurst = !inBurst;
+        nextBurstSwitch = DateTimeOffset.UtcNow + (inBurst ? burstDuration : burstPause);
+    }
+
     foreach (var dev in devices)
     {
         if (seqs[dev] == long.MaxValue)
@@ -58,6 +89,36 @@ while (true)
         props.Persistent = true;
         channel.BasicPublish(exchange: "", routingKey: "telemetry", basicProperties: props, body: body);
         Console.WriteLine($"Published {dev} seq {seq}");
-        await Task.Delay(500);
+        await Task.Delay(inBurst ? burstInterval : baseInterval);
     }
+}
+
+static int? GetIntArgValue(string[] args, string key)
+{
+    var value = GetArgValue(args, key);
+    return int.TryParse(value, out var parsed) ? parsed : null;
+}
+
+static string? GetArgValue(string[] args, string key)
+{
+    for (var i = 0; i < args.Length - 1; i++)
+    {
+        if (string.Equals(args[i], key, StringComparison.OrdinalIgnoreCase))
+        {
+            return args[i + 1];
+        }
+    }
+
+    return null;
+}
+
+static int? GetIntEnvValue(string key)
+{
+    return int.TryParse(Environment.GetEnvironmentVariable(key), out var value) ? value : null;
+}
+
+static bool GetBoolEnvValue(string key)
+{
+    var value = Environment.GetEnvironmentVariable(key);
+    return bool.TryParse(value, out var parsed) && parsed;
 }


### PR DESCRIPTION
### Motivation
- Add RabbitMQ-focused load scenarios (soak, spike, mixed) to exercise the ingest pipeline under realistic messaging patterns. 
- Support multi-connector test runs and capture connector-level metrics to understand producer-side behavior under backpressure. 
- Make the test publisher configurable to drive burst/spike traffic and scale the number of simulated devices. 
- Improve reporting and resource cleanup by recording connector configuration in reports and disposing connectors after each stage.

### Description
- Extended `LoadStage` with `LoadTestConnectorCount` and `UseRabbitMqConnector` and added new stage builders `BuildRabbitMqSoakStages`, `BuildRabbitMqSpikeStages`, and `BuildMultiConnectorStages`.
- Implemented `BuildConnectors` to create multiple `LoadTestConnector` instances and optionally a `RabbitMqIngestConnector` wrapped by `InstrumentedConnector` which uses `MetricsChannelWriter` to record produce timing.
- Updated the load test runner to accept multiple connectors, set `TelemetryIngestOptions.Enabled` from connector names, call `DisposeConnectorsAsync` after each stage, and include connector summary fields in the generated report.
- Added publisher runtime options (args/env) for device count and burst behavior (`--burst`, `--burst-interval-ms`, `--burst-duration-sec`, `--burst-pause-sec`) and implemented burst timing logic in the publisher loop.

### Testing
- No automated tests were executed as part of this change.
- Basic manual validation was not recorded in automated test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962f36e38108326b24e062fa130a686)