### PR TITLE
test(admin): implement Phase 2 AdminGateway bUnit UI test coverage

### DIFF
--- a/orleans-telemetry-sample.sln
+++ b/orleans-telemetry-sample.sln
@@ -40,6 +40,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiGateway.Contracts", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelemetryClient", "src\TelemetryClient\TelemetryClient.csproj", "{63D6F056-F215-47CD-99FE-7CEE8CFAD8B2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdminGateway.Tests", "src\AdminGateway.Tests\AdminGateway.Tests.csproj", "{0158B1FF-5ED1-404A-87C0-8C03316441CA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -118,6 +120,10 @@ Global
 		{63D6F056-F215-47CD-99FE-7CEE8CFAD8B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63D6F056-F215-47CD-99FE-7CEE8CFAD8B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63D6F056-F215-47CD-99FE-7CEE8CFAD8B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0158B1FF-5ED1-404A-87C0-8C03316441CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0158B1FF-5ED1-404A-87C0-8C03316441CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0158B1FF-5ED1-404A-87C0-8C03316441CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0158B1FF-5ED1-404A-87C0-8C03316441CA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -141,6 +147,7 @@ Global
 		{157F67B7-E62F-4B9F-8681-321C1AC17743} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{D493AF95-161C-4EAC-B9D2-946C2C927C36} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{63D6F056-F215-47CD-99FE-7CEE8CFAD8B2} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{0158B1FF-5ED1-404A-87C0-8C03316441CA} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AD704E7C-6C65-40D6-BB54-132EA9BC969A}

--- a/plans.md
+++ b/plans.md
@@ -964,6 +964,9 @@ GraphNodeGrain と PointGrain の関連を API で活用し、`/api/nodes/{nodeI
 ## Purpose
 AdminGateway について、RDF を入力として grain を生成し、ツリー UI の動作を継続検証できるテスト戦略を定義する。
 
+### 現在フェーズ
+- **Phase 2: Blazor UI テストを追加する** を完了。次は Phase 3（E2E UI テスト）に進む。
+
 ## Success Criteria
 1. AdminGateway の現行フロー（RDF→GraphSeed→AdminMetricsService→MudTreeView）を前提に、層別テスト方針（データ/サービス/UI/E2E）を文書化する。
 2. 最小実行単位（最初のスプリント）で着手できるテスト導入ステップを明示する。
@@ -974,22 +977,29 @@ AdminGateway について、RDF を入力として grain を生成し、ツリ�
 2. 設計方針ドキュメントを `docs/` に追加する。
 3. README の Documentation セクションにリンクを追加する。
 4. `dotnet build` / `dotnet test` で回帰確認する。
+5. Phase 2 として `AdminGateway.Tests` に bUnit を導入し、`Admin.razor` の表示/選択 UI テストを追加する。
+6. `dotnet test src/AdminGateway.Tests` を実行し、Phase 2 の追加テストが通ることを確認する。
 
 ## Progress
 - [x] AdminGateway の構造と既存ドキュメントを確認
 - [x] 設計方針ドキュメントを追加
 - [x] README へのリンク追加
 - [x] ビルド/テストの実行結果を記録
+- [x] Phase 1 (サービス層テスト方針の確定)
+- [x] Phase 2 (bUnit UI テスト実装)
+- [x] Phase 2 のテスト実行確認 (`dotnet test src/AdminGateway.Tests`)
 
 ## Observations
-- `AdminGateway` 用の専用テストプロジェクトは現時点で存在しない。
+- `src/AdminGateway.Tests` を新設し、bUnit + xUnit + Moq で `Admin.razor` の UI テスト実行基盤を追加した。
 - ツリー構築ロジックは `AdminMetricsService` 内に集約されており、関係解釈（`hasPart`/`isPartOf`/`locatedIn`/`isLocationOf`）と `Device` 正規化が主要なテスト対象。
-- `dotnet build` と `dotnet test` は通過し、回帰は発生していない。
+- `dotnet test src/AdminGateway.Tests` で Phase 2 の 2 テスト（ツリー表示 / ノード選択詳細表示）を追加し通過した。
+- `AdminMetricsService` が concrete + internal のため、`AdminGateway` 側に `InternalsVisibleTo("AdminGateway.Tests")` を追加してテストから DI 構成できるようにした。
 
 ## Decisions
 - 今回はコード実装より先に、導入順序が明確なテスト設計方針をドキュメント化する。
 - 層A（RDF解析）/層B（サービス）/層C（bUnit UI）/統合D（Playwright E2E）の 4 区分で段階導入する。
+- Phase 2 はまず `Admin.razor` の最小 2 ケース（階層表示 / ノード選択）で固定し、壊れやすい表示ロジックを PR ごとに検知できる形にする。
 
 ## Retrospective
-- ドキュメント先行でテスト実装方針を固定できたため、次の実装タスクで `AdminGateway.Tests` を迷わず起票できる状態になった。
+- Phase 2 の最小スコープ（表示 + ノード選択）を実装できたため、次は Phase 3 の Playwright E2E へ接続しやすい土台が整った。
 - `dotnet build` / `dotnet test` は成功したが、既存 warning（MudBlazor 近似解決、Moq 脆弱性通知、XML コメント警告）は継続しているため別タスクでの解消が必要。

--- a/src/AdminGateway.Tests/AdminGateway.Tests.csproj
+++ b/src/AdminGateway.Tests/AdminGateway.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="bunit" Version="1.30.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../AdminGateway/AdminGateway.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/AdminGateway.Tests/AdminPageTests.cs
+++ b/src/AdminGateway.Tests/AdminPageTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AdminGateway.Models;
+using AdminGateway.Pages;
+using AdminGateway.Services;
+using Bunit;
+using Grains.Abstractions;
+using System.Reflection;
+using Bunit.JSInterop;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using MudBlazor.Services;
+using Orleans;
+using Telemetry.Ingest;
+using Telemetry.Storage;
+
+namespace AdminGateway.Tests;
+
+public sealed class AdminPageTests : TestContext
+{
+    [Fact]
+    public void LoadHierarchy_ShowsTreePanelAndNodeLabel()
+    {
+        var metrics = CreateMetricsService(
+            tenants: new[] { "t1" },
+            idsByType: new Dictionary<GraphNodeType, IReadOnlyList<string>>
+            {
+                [GraphNodeType.Site] = new[] { "site-1" },
+                [GraphNodeType.Equipment] = new[] { "equip-1" }
+            },
+            snapshots: new Dictionary<string, GraphNodeSnapshot>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["site-1"] = Snapshot("site-1", "HQ Site", GraphNodeType.Site,
+                    new GraphEdge { Predicate = "hasEquipment", TargetNodeId = "equip-1" }),
+                ["equip-1"] = Snapshot("equip-1", "AHU-1", GraphNodeType.Equipment)
+            });
+
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton(metrics);
+
+        var cut = RenderComponent<Admin>();
+
+        ClickButton(cut, "Load Hierarchy");
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Hierarchy Tree", cut.Markup);
+            Assert.Contains("HQ Site", cut.Markup);
+            Assert.Contains("AHU-1", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task SelectingTreeNode_ShowsNormalizedClassAndAttributes()
+    {
+        var metrics = CreateMetricsService(
+            tenants: new[] { "t1" },
+            idsByType: new Dictionary<GraphNodeType, IReadOnlyList<string>>
+            {
+                [GraphNodeType.Device] = new[] { "device-01" }
+            },
+            snapshots: new Dictionary<string, GraphNodeSnapshot>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["device-01"] = new GraphNodeSnapshot
+                {
+                    Node = new GraphNodeDefinition
+                    {
+                        NodeId = "device-01",
+                        DisplayName = "AHU Device",
+                        NodeType = GraphNodeType.Device,
+                        Attributes = new Dictionary<string, string>
+                        {
+                            ["manufacturer"] = "Contoso"
+                        }
+                    }
+                }
+            });
+
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton(metrics);
+
+        var cut = RenderComponent<Admin>();
+
+        ClickButton(cut, "Load Hierarchy");
+        cut.WaitForAssertion(() => Assert.Contains("AHU Device", cut.Markup));
+
+        await cut.InvokeAsync(() => InvokePrivateAsync(cut.Instance, "SelectGraphNodeAsync", "device-01"));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("ID:</strong> device-01", cut.Markup);
+            Assert.Contains("Class:</strong> Equipment", cut.Markup);
+            Assert.Contains("manufacturer: Contoso", cut.Markup);
+        });
+    }
+
+
+    private static Task InvokePrivateAsync(object target, string methodName, params object[] args)
+    {
+        var method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Method '{methodName}' was not found.");
+
+        return (Task)(method.Invoke(target, args)
+            ?? throw new InvalidOperationException($"Method '{methodName}' returned null."));
+    }
+
+    private static void ClickButton(IRenderedComponent<Admin> cut, string text)
+    {
+        cut.WaitForAssertion(() =>
+        {
+            var exists = cut.FindAll("button")
+                .Any(b => b.TextContent.Contains(text, StringComparison.Ordinal));
+            Assert.True(exists, $"Button '{text}' was not rendered yet.");
+        });
+
+        var button = cut.FindAll("button")
+            .First(b => b.TextContent.Contains(text, StringComparison.Ordinal));
+        button.Click();
+    }
+
+    private static GraphNodeSnapshot Snapshot(string id, string displayName, GraphNodeType type, params GraphEdge[] outgoingEdges)
+        => new()
+        {
+            Node = new GraphNodeDefinition
+            {
+                NodeId = id,
+                DisplayName = displayName,
+                NodeType = type
+            },
+            OutgoingEdges = outgoingEdges.ToList()
+        };
+
+    private static AdminMetricsService CreateMetricsService(
+        IReadOnlyList<string> tenants,
+        IReadOnlyDictionary<GraphNodeType, IReadOnlyList<string>> idsByType,
+        IReadOnlyDictionary<string, GraphNodeSnapshot> snapshots)
+    {
+        var registry = new Mock<IGraphTenantRegistryGrain>();
+        registry.Setup(x => x.GetTenantIdsAsync()).ReturnsAsync(tenants);
+
+        var index = new Mock<IGraphIndexGrain>();
+        index.Setup(x => x.GetByTypeAsync(It.IsAny<GraphNodeType>()))
+            .ReturnsAsync((GraphNodeType type) => idsByType.TryGetValue(type, out var ids)
+                ? ids
+                : Array.Empty<string>());
+
+        var client = new Mock<IClusterClient>();
+        client
+            .Setup(c => c.GetGrain<IGraphTenantRegistryGrain>(It.IsAny<long>(), It.IsAny<string?>()))
+            .Returns(registry.Object);
+        client
+            .Setup(c => c.GetGrain<IGraphIndexGrain>(It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns(index.Object);
+        client
+            .Setup(c => c.GetGrain<IGraphNodeGrain>(It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns<string, string?>((key, _) =>
+            {
+                var nodeId = key.Contains(':') ? key[(key.IndexOf(':') + 1)..] : key;
+                var grain = new Mock<IGraphNodeGrain>();
+                grain.Setup(g => g.GetAsync()).ReturnsAsync(
+                    snapshots.TryGetValue(nodeId, out var snapshot)
+                        ? snapshot
+                        : new GraphNodeSnapshot
+                        {
+                            Node = new GraphNodeDefinition
+                            {
+                                NodeId = nodeId,
+                                DisplayName = nodeId,
+                                NodeType = GraphNodeType.Unknown
+                            }
+                        });
+                return grain.Object;
+            });
+
+        var storageScanner = new TelemetryStorageScanner(
+            Options.Create(new TelemetryStorageOptions
+            {
+                StagePath = "./not-used-stage",
+                ParquetPath = "./not-used-parquet",
+                IndexPath = "./not-used-index"
+            }),
+            NullLogger<TelemetryStorageScanner>.Instance);
+
+        return new AdminMetricsService(
+            client.Object,
+            storageScanner,
+            Options.Create(new TelemetryIngestOptions()),
+            NullLogger<AdminMetricsService>.Instance);
+    }
+}

--- a/src/AdminGateway/Pages/Admin.razor
+++ b/src/AdminGateway/Pages/Admin.razor
@@ -501,7 +501,7 @@ else
             builder.AddAttribute(sequence++, "Text", node.DisplayName);
             builder.AddAttribute(sequence++, "Icon", GetTreeIcon(node.NodeType));
             builder.AddAttribute(sequence++, "CanExpand", node.Children.Count > 0);
-            builder.AddAttribute(sequence++, "OnClick", EventCallback.Factory.Create(this, () => SelectGraphNodeAsync(node.NodeId)));
+            builder.AddAttribute(sequence++, "OnClick", EventCallback.Factory.Create<MouseEventArgs>(this, _ => SelectGraphNodeAsync(node.NodeId)));
             if (node.Children.Count > 0)
             {
                 builder.AddAttribute(sequence++, "ChildContent", RenderGraphTree(node.Children));

--- a/src/AdminGateway/Properties/AssemblyInfo.cs
+++ b/src/AdminGateway/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AdminGateway.Tests")]


### PR DESCRIPTION
### Motivation
- Implement Phase 2 from the project plan to add Blazor component tests that validate `Admin.razor` rendering and node-selection behavior so UI regressions are detected early.
- Provide a minimal, testable surface (bUnit + xUnit + Moq) for the AdminGateway UI layer without changing public APIs.

### Description
- Added a new test project `src/AdminGateway.Tests` (xUnit) with `bUnit`, `Moq`, and a project reference to `AdminGateway` to host component tests.
- Implemented two bUnit tests in `src/AdminGateway.Tests/AdminPageTests.cs` that verify hierarchy rendering and node selection/detail display (including `Device -> Equipment` normalization).
- Updated `src/AdminGateway/Pages/Admin.razor` to use a typed `EventCallback<MouseEventArgs>` for `MudTreeViewItem.OnClick` to fix runtime typing incompatibility with MudBlazor in tests.
- Added `src/AdminGateway/Properties/AssemblyInfo.cs` with `InternalsVisibleTo("AdminGateway.Tests")` and added the test project to the solution file so tests can compose internal services; updated `plans.md` progress/observations to mark Phase 2 complete.

### Testing
- Ran `dotnet test src/AdminGateway.Tests` and the two new bUnit tests passed (green) with only existing NuGet/warning notices as before.
- Ran `dotnet build` on the solution and the build succeeded (warnings only) and `dotnet test` across the solution completed with all tests passing, including `AdminGateway.Tests`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698527978a2c8326a890550643563ee5)