### PR TITLE
Fix E2E tests by setting Orleans gateway env in tests

### DIFF
--- a/plans.md
+++ b/plans.md
@@ -2,6 +2,38 @@
 
 ---
 
+# plans.md: Validate Tests and Fix Failures (2026-??-??)
+
+## Purpose
+Run the test suite, identify failures, and apply minimal fixes so tests complete without errors.
+
+## Success Criteria
+1. `dotnet test` completes without errors (or remaining failures documented).
+2. Any fixes are minimal and recorded in this plan.
+3. Verification commands and results are documented.
+
+## Steps
+1. Run `dotnet test` to collect failures.
+2. Diagnose and apply minimal fixes.
+3. Re-run relevant tests to confirm.
+
+## Progress
+- [x] Run `dotnet test`
+- [x] Apply fixes (if needed)
+- [x] Re-run tests
+
+## Observations
+- `dotnet test` initially failed in `Telemetry.E2E.Tests` because ApiGateway attempted to connect to the default Orleans gateway port (30000) and received connection refused.
+- The config overrides supplied to `ApiGatewayFactory` were not applied early enough for Program startup, so ApiGateway fell back to defaults.
+
+## Decisions
+- Set `Orleans__GatewayHost`/`Orleans__GatewayPort` environment variables in the E2E tests before starting the ApiGateway factory to ensure the gateway port matches the test silo.
+
+## Retrospective
+- `dotnet test` passes after applying the gateway environment overrides.
+
+---
+
 # plans.md: Wait for Orleans Gateway Port Before Starting API in E2E
 
 ## Purpose

--- a/src/Telemetry.E2E.Tests/TelemetryE2ETests.cs
+++ b/src/Telemetry.E2E.Tests/TelemetryE2ETests.cs
@@ -87,6 +87,9 @@ public sealed class TelemetryE2ETests
             siloStarted = true;
             await WaitForPortAsync(gatewayPort, TimeSpan.FromSeconds(5));
 
+            Environment.SetEnvironmentVariable("Orleans__GatewayHost", "127.0.0.1");
+            Environment.SetEnvironmentVariable("Orleans__GatewayPort", gatewayPort.ToString());
+
             var apiConfig = BuildApiConfig(stageRoot, parquetRoot, indexRoot, gatewayPort);
             apiFactory = new ApiGatewayFactory(apiConfig);
             using var client = apiFactory.CreateClient();
@@ -195,6 +198,8 @@ public sealed class TelemetryE2ETests
 
             Environment.SetEnvironmentVariable("RDF_SEED_PATH", null);
             Environment.SetEnvironmentVariable("TENANT_ID", null);
+            Environment.SetEnvironmentVariable("Orleans__GatewayHost", null);
+            Environment.SetEnvironmentVariable("Orleans__GatewayPort", null);
         }
     }
 
@@ -239,6 +244,9 @@ public sealed class TelemetryE2ETests
             await siloHost.StartAsync();
             siloStarted = true;
             await WaitForPortAsync(gatewayPort, TimeSpan.FromSeconds(5));
+
+            Environment.SetEnvironmentVariable("Orleans__GatewayHost", "127.0.0.1");
+            Environment.SetEnvironmentVariable("Orleans__GatewayPort", gatewayPort.ToString());
 
             var apiConfig = BuildApiConfig(stageRoot, parquetRoot, indexRoot, gatewayPort);
             apiFactory = new ApiGatewayFactory(apiConfig);
@@ -304,6 +312,8 @@ public sealed class TelemetryE2ETests
 
             Environment.SetEnvironmentVariable("RDF_SEED_PATH", null);
             Environment.SetEnvironmentVariable("TENANT_ID", null);
+            Environment.SetEnvironmentVariable("Orleans__GatewayHost", null);
+            Environment.SetEnvironmentVariable("Orleans__GatewayPort", null);
         }
     }
 


### PR DESCRIPTION
### Motivation
- E2E tests intermittently failed because the ApiGateway attempted to connect to the default Orleans gateway port before test-specific config was applied, causing `ConnectionRefused` errors. 
- The test harness supplied config overrides to `ApiGatewayFactory`, but the overrides were not taking effect early enough during Program startup, so the Api client fell back to defaults.

### Description
- Set `Orleans__GatewayHost` and `Orleans__GatewayPort` environment variables in `src/Telemetry.E2E.Tests/TelemetryE2ETests.cs` before creating the `ApiGatewayFactory` so the API client connects to the test silo gateway. 
- Clear the environment variables in the test `finally` blocks to avoid cross-test leakage. 
- Documented the observed failure, decision, and resolution in `plans.md` under a new “Validate Tests and Fix Failures” entry.

### Testing
- Ran the full test suite with `dotnet test` and observed initial failures in `Telemetry.E2E.Tests` related to Orleans gateway connection, then re-ran after the fix and confirmed all tests pass. 
- Result: `dotnet test` completed successfully (E2E tests included) after applying the gateway environment overrides.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fc7d6b488326b43e2ff5de7f0d40)