### PR TITLE
Filter ingest pipeline to drop unregistered telemetry points

### DIFF
--- a/src/SiloHost/GraphRegisteredTelemetryPointFilter.cs
+++ b/src/SiloHost/GraphRegisteredTelemetryPointFilter.cs
@@ -1,0 +1,74 @@
+using Grains.Abstractions;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Telemetry.Ingest;
+
+namespace SiloHost;
+
+public sealed class GraphRegisteredTelemetryPointFilter : ITelemetryPointRegistrationFilter
+{
+    private readonly IGrainFactory _grainFactory;
+    private readonly ILogger<GraphRegisteredTelemetryPointFilter> _logger;
+
+    public GraphRegisteredTelemetryPointFilter(
+        IGrainFactory grainFactory,
+        ILogger<GraphRegisteredTelemetryPointFilter> logger)
+    {
+        _grainFactory = grainFactory;
+        _logger = logger;
+    }
+
+    public async Task<bool> IsRegisteredAsync(TelemetryPointMsg message, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(message.TenantId) || string.IsNullOrWhiteSpace(message.PointId))
+        {
+            return false;
+        }
+
+        try
+        {
+            var index = _grainFactory.GetGrain<IGraphIndexGrain>(message.TenantId);
+            var pointNodeIds = await index.GetByTypeAsync(GraphNodeType.Point);
+            if (pointNodeIds.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (var nodeId in pointNodeIds)
+            {
+                var nodeGrain = _grainFactory.GetGrain<IGraphNodeGrain>(GraphNodeKey.Create(message.TenantId, nodeId));
+                var snapshot = await nodeGrain.GetAsync();
+                if (snapshot.Node?.Attributes is null)
+                {
+                    continue;
+                }
+
+                if (!snapshot.Node.Attributes.TryGetValue("PointId", out var pointId)
+                    || !string.Equals(pointId, message.PointId, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (snapshot.Node.Attributes.TryGetValue("DeviceId", out var deviceId)
+                    && !string.IsNullOrWhiteSpace(deviceId)
+                    && !string.Equals(deviceId, message.DeviceId, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to evaluate telemetry registration. TenantId={TenantId}, DeviceId={DeviceId}, PointId={PointId}",
+                message.TenantId,
+                message.DeviceId,
+                message.PointId);
+            return false;
+        }
+    }
+}

--- a/src/SiloHost/Program.cs
+++ b/src/SiloHost/Program.cs
@@ -34,6 +34,7 @@ internal static class Program
             var ingestSection = context.Configuration.GetSection("TelemetryIngest");
             var storageSection = context.Configuration.GetSection("TelemetryStorage");
             services.AddTelemetryIngest(ingestSection);
+            services.AddSingleton<ITelemetryPointRegistrationFilter, GraphRegisteredTelemetryPointFilter>();
             // Connector registration stays in code; config controls which ones are enabled.
             services.AddKafkaIngest(ingestSection.GetSection("Kafka"));
             services.AddRabbitMqIngest(ingestSection.GetSection("RabbitMq"));

--- a/src/Telemetry.Ingest.LoadTest/Program.cs
+++ b/src/Telemetry.Ingest.LoadTest/Program.cs
@@ -94,6 +94,7 @@ internal static class Program
                 connectors,
                 new[] { sink },
                 router,
+                new AllowAllTelemetryPointRegistrationFilter(),
                 options,
                 NullLogger<TelemetryIngestCoordinator>.Instance);
 

--- a/src/Telemetry.Ingest/ITelemetryPointRegistrationFilter.cs
+++ b/src/Telemetry.Ingest/ITelemetryPointRegistrationFilter.cs
@@ -1,0 +1,14 @@
+using Grains.Abstractions;
+
+namespace Telemetry.Ingest;
+
+public interface ITelemetryPointRegistrationFilter
+{
+    Task<bool> IsRegisteredAsync(TelemetryPointMsg message, CancellationToken cancellationToken);
+}
+
+public sealed class AllowAllTelemetryPointRegistrationFilter : ITelemetryPointRegistrationFilter
+{
+    public Task<bool> IsRegisteredAsync(TelemetryPointMsg message, CancellationToken cancellationToken)
+        => Task.FromResult(true);
+}

--- a/src/Telemetry.Ingest/TelemetryIngestServiceCollectionExtensions.cs
+++ b/src/Telemetry.Ingest/TelemetryIngestServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ public static class TelemetryIngestServiceCollectionExtensions
         IConfiguration configuration)
     {
         services.Configure<TelemetryIngestOptions>(configuration);
+        services.AddSingleton<ITelemetryPointRegistrationFilter, AllowAllTelemetryPointRegistrationFilter>();
         services.AddHostedService<TelemetryIngestCoordinator>();
         return services;
     }


### PR DESCRIPTION
### Motivation

- Prevent telemetry that is not defined in the RDF/graph from being routed to grains or persisted by sinks.
- Use tenantID/deviceID/pointID as the identity for telemetry and treat `spaceId` as optional when deciding registration.

### Description

- Add `ITelemetryPointRegistrationFilter` (with `AllowAllTelemetryPointRegistrationFilter`) and make `TelemetryIngestCoordinator` consult it to drop unregistered messages before routing and sink writes (files: `src/Telemetry.Ingest/ITelemetryPointRegistrationFilter.cs`, `src/Telemetry.Ingest/TelemetryIngestCoordinator.cs`).
- Add `GraphRegisteredTelemetryPointFilter` in `SiloHost` that checks the graph registry (`IGraphIndexGrain`/`IGraphNodeGrain`) and validates by `tenantId + pointId` (and `deviceId` when present), and register it in DI so Silo hosts enforce graph-only ingestion (file: `src/SiloHost/GraphRegisteredTelemetryPointFilter.cs`, DI change in `src/SiloHost/Program.cs`).
- Wire a default allow-all filter in `Telemetry.Ingest` service registration so behavior is backwards-compatible and update the load-test coordinator construction to pass the new dependency (files: `src/Telemetry.Ingest/TelemetryIngestServiceCollectionExtensions.cs`, `src/Telemetry.Ingest.LoadTest/Program.cs`).
- Add unit test covering drop behavior (`CoordinatorDropsUnregisteredTelemetryBeforeRoutingAndSinks`) and test helpers to `TelemetryIngestCoordinator` tests, and update `plans.md` to record purpose and verification (file: `src/Telemetry.Ingest.Tests/TelemetryIngestCoordinatorTests.cs`, `plans.md`).

### Testing

- Ran `dotnet build` and the solution built successfully with no errors.
- Ran `dotnet test` and all test projects passed, including the new ingest coordinator test (`CoordinatorDropsUnregisteredTelemetryBeforeRoutingAndSinks`).
- Verification demonstrates that unregistered telemetry is discarded before it reaches the router or event sinks during ingest.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb1615f78832684f3f3ae4a96c4e0)