### PR TITLE
Add embedded SPARQL grain, API endpoints, tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ graph LR
 
 機能別ドキュメント:
 - [API Gateway API](docs/api-gateway-apis.md)
+- [SPARQL クエリ機能](docs/sparql-query-service.md)
 - [コネクタ & テレメトリーインジェスト](docs/telemetry-connector-ingest.md)
 - [MQTT コネクタ設計](docs/mqtt-connector-design.md)
 - [ルーティングと値バインディング](docs/telemetry-routing-binding.md)
@@ -57,6 +58,17 @@ graph LR
 - [負荷試験ガイド](docs/telemetry-ingest-loadtest.md)
 - [OpenTelemetry 運用メモ](docs/observability-opentelemetry.md)
 - [Orleans クラスタリングとスケーラビリティ](docs/clustering-and-scalability.md)
+
+
+## SPARQL Query (API Gateway 経由)
+
+API Gateway には SPARQL 用の REST エンドポイントが追加されています（認証必須）。
+
+- `POST /api/sparql/load`: RDF データをロード
+- `POST /api/sparql/query`: SPARQL SELECT/ASK クエリを実行
+- `GET /api/sparql/stats`: テナント単位のトリプル数を取得
+
+詳細は [docs/sparql-query-service.md](docs/sparql-query-service.md) を参照してください。
 
 ## Build & Test
 

--- a/docs/api-gateway-apis.md
+++ b/docs/api-gateway-apis.md
@@ -162,6 +162,16 @@ ApiGateway は Orleans の最新状態・グラフ・履歴データを REST API
   - `404 NotFound`
   - `410 Gone`
 
+### SPARQL クエリ
+
+`POST /api/sparql/load`
+`POST /api/sparql/query`
+`GET /api/sparql/stats`
+
+- 説明: RDF ロード、SPARQL 実行、テナント単位 triple 数取得を提供します。
+- 認証: 必須（JWT）
+- 備考: 返却フォーマット詳細は `docs/sparql-query-service.md` を参照してください。
+
 ## gRPC API（現状と拡張計画）
 
 gRPC は `devices.proto` ベースで一部実装済みです。現状の提供 API と、将来的な拡張計画を以下に整理します。

--- a/docs/sparql-query-service.md
+++ b/docs/sparql-query-service.md
@@ -1,0 +1,103 @@
+# SPARQL Query Service
+
+このドキュメントは、Embedded SPARQL Query Engine for RDF の現状実装を説明します。
+
+## 概要
+
+現状の SPARQL 機能は以下の構成です。
+
+- `SiloHost` 側に `SparqlQueryGrain` を実装
+- `ApiGateway` から REST 経由で SPARQL クエリを実行
+- テナントは JWT の `tenant` claim で分離
+
+実装上、SPARQL データは Grain ID `"sparql"` の `ISparqlQueryGrain` に保存され、
+テナントごとに triple を分離して保持します。
+
+## エンドポイント
+
+認証必須（`Authorization: Bearer <token>`）です。
+
+### 1. RDF ロード
+
+`POST /api/sparql/load`
+
+Request body:
+
+```json
+{
+  "content": "@prefix brick: <https://brickschema.org/schema/Brick#> . <urn:building1> a brick:Building .",
+  "format": "turtle"
+}
+```
+
+- `content`: RDF 本文（必須）
+- `format`: RDF フォーマット（必須）
+  - 現在の Grain 実装は `turtle`, `ntriples`, `rdfxml` 系をサポート
+
+### 2. SPARQL クエリ実行
+
+`POST /api/sparql/query`
+
+Request body:
+
+```json
+{
+  "query": "SELECT ?s WHERE { ?s a <https://brickschema.org/schema/Brick#Building> }"
+}
+```
+
+Response body（例）:
+
+```json
+{
+  "isBooleanResult": false,
+  "booleanResult": false,
+  "variables": ["s"],
+  "rows": [
+    { "values": { "s": "urn:building1" } }
+  ]
+}
+```
+
+### 3. 統計情報
+
+`GET /api/sparql/stats`
+
+Response body（例）:
+
+```json
+{
+  "tripleCount": 2
+}
+```
+
+## cURL サンプル
+
+```bash
+# 1) RDF ロード
+curl -X POST http://localhost:8080/api/sparql/load \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"content":"@prefix brick: <https://brickschema.org/schema/Brick#> . <urn:building1> a brick:Building .","format":"turtle"}'
+
+# 2) クエリ実行
+curl -X POST http://localhost:8080/api/sparql/query \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"SELECT ?s WHERE { ?s a <https://brickschema.org/schema/Brick#Building> }"}'
+
+# 3) テナント単位トリプル数
+curl -X GET http://localhost:8080/api/sparql/stats \
+  -H "Authorization: Bearer <token>"
+```
+
+## 実装・テスト対応状況
+
+- Grain 単体テスト: `SparqlQueryGrainTests`
+- API Gateway 統合テスト: `SparqlEndpointTests`
+
+将来的には以下を拡張予定です。
+
+- `Sparql:Enabled` などの機能フラグ
+- 外部 SPARQL Endpoint 抽象化（HTTP 接続）
+- E2E テストの追加

--- a/src/ApiGateway.Tests/SparqlEndpointTests.cs
+++ b/src/ApiGateway.Tests/SparqlEndpointTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using ApiGateway.Sparql;
+using FluentAssertions;
+using Grains.Abstractions;
+using Moq;
+using Xunit;
+
+namespace ApiGateway.Tests;
+
+public sealed class SparqlEndpointTests
+{
+    [Fact]
+    public async Task POST_api_sparql_query_with_select_returns_results()
+    {
+        var grainMock = new Mock<ISparqlQueryGrain>();
+        grainMock.Setup(g => g.ExecuteQueryAsync("SELECT * WHERE { ?s ?p ?o } LIMIT 1", "tenant-a"))
+            .ReturnsAsync(new SparqlQueryResult
+            {
+                Variables = new List<string> { "s" },
+                Rows = new List<SparqlResultBinding>
+                {
+                    new() { Values = new Dictionary<string, string> { ["s"] = "urn:building1" } }
+                }
+            });
+
+        var clusterMock = new Mock<IClusterClient>();
+        clusterMock
+            .Setup(c => c.GetGrain<ISparqlQueryGrain>("sparql", It.IsAny<string?>()))
+            .Returns(grainMock.Object);
+
+        await using var factory = new ApiGatewayTestFactory(clusterMock);
+        var client = factory.CreateClient();
+        TestAuthHandler.Reset();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Test", "tenant=tenant-a");
+
+        var response = await client.PostAsJsonAsync("/api/sparql/query", new SparqlQueryRequest
+        {
+            Query = "SELECT * WHERE { ?s ?p ?o } LIMIT 1"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<SparqlQueryResult>();
+        body.Should().NotBeNull();
+        body!.Rows.Should().ContainSingle();
+        body.Rows[0].Values["s"].Should().Be("urn:building1");
+
+        clusterMock.Verify(c => c.GetGrain<ISparqlQueryGrain>("sparql", It.IsAny<string?>()), Times.Once);
+        grainMock.Verify(g => g.ExecuteQueryAsync("SELECT * WHERE { ?s ?p ?o } LIMIT 1", "tenant-a"), Times.Once);
+    }
+
+    [Fact]
+    public async Task POST_api_sparql_load_without_auth_returns_401()
+    {
+        var clusterMock = new Mock<IClusterClient>();
+        await using var factory = new ApiGatewayTestFactory(clusterMock);
+        var client = factory.CreateClient();
+        TestAuthHandler.Reset();
+        client.DefaultRequestHeaders.Clear();
+
+        var response = await client.PostAsJsonAsync("/api/sparql/load", new SparqlLoadRequest
+        {
+            Content = "@prefix brick: <https://brickschema.org/schema/Brick#> . <urn:b> a brick:Building .",
+            Format = "turtle"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GET_api_sparql_stats_returns_triple_count()
+    {
+        var grainMock = new Mock<ISparqlQueryGrain>();
+        grainMock.Setup(g => g.GetTripleCountAsync("tenant-z")).ReturnsAsync(42);
+
+        var clusterMock = new Mock<IClusterClient>();
+        clusterMock
+            .Setup(c => c.GetGrain<ISparqlQueryGrain>("sparql", It.IsAny<string?>()))
+            .Returns(grainMock.Object);
+
+        await using var factory = new ApiGatewayTestFactory(clusterMock);
+        var client = factory.CreateClient();
+        TestAuthHandler.Reset();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Test", "tenant=tenant-z");
+
+        var response = await client.GetAsync("/api/sparql/stats");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<SparqlStatsResponse>();
+        body.Should().NotBeNull();
+        body!.TripleCount.Should().Be(42);
+        grainMock.Verify(g => g.GetTripleCountAsync("tenant-z"), Times.Once);
+    }
+}

--- a/src/ApiGateway/Sparql/SparqlRequests.cs
+++ b/src/ApiGateway/Sparql/SparqlRequests.cs
@@ -1,0 +1,12 @@
+namespace ApiGateway.Sparql;
+
+public sealed class SparqlQueryRequest
+{
+    public string Query { get; set; } = string.Empty;
+}
+
+public sealed class SparqlLoadRequest
+{
+    public string Content { get; set; } = string.Empty;
+    public string Format { get; set; } = "turtle";
+}

--- a/src/ApiGateway/Sparql/SparqlResponses.cs
+++ b/src/ApiGateway/Sparql/SparqlResponses.cs
@@ -1,0 +1,3 @@
+namespace ApiGateway.Sparql;
+
+public sealed record SparqlStatsResponse(int TripleCount);

--- a/src/Grains.Abstractions/SparqlContracts.cs
+++ b/src/Grains.Abstractions/SparqlContracts.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using Orleans;
+
+namespace Grains.Abstractions;
+
+public interface ISparqlQueryGrain : IGrainWithStringKey
+{
+    Task LoadRdfAsync(string rdfContent, string format, string tenantId);
+    Task<SparqlQueryResult> ExecuteQueryAsync(string sparqlQuery, string tenantId);
+    Task<int> GetTripleCountAsync(string tenantId);
+    Task ClearAsync(string tenantId);
+}
+
+[GenerateSerializer]
+public sealed class SparqlQueryResult
+{
+    [Id(0)] public bool IsBooleanResult { get; set; }
+    [Id(1)] public bool BooleanResult { get; set; }
+    [Id(2)] public List<string> Variables { get; set; } = new();
+    [Id(3)] public List<SparqlResultBinding> Rows { get; set; } = new();
+}
+
+[GenerateSerializer]
+public sealed class SparqlResultBinding
+{
+    [Id(0)] public Dictionary<string, string> Values { get; set; } = new();
+}

--- a/src/SiloHost.Tests/SparqlQueryGrainTests.cs
+++ b/src/SiloHost.Tests/SparqlQueryGrainTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Xunit;
+
+namespace SiloHost.Tests;
+
+public sealed class SparqlQueryGrainTests
+{
+    private const string BuildingTurtle = """
+        @prefix brick: <https://brickschema.org/schema/Brick#> .
+        <urn:building1> a brick:Building .
+        <urn:building1> brick:label "HQ" .
+        """;
+
+    [Fact]
+    public async Task LoadRdfAsync_ParsesTurtleAndStoresTriples()
+    {
+        var persistence = new TestPersistentState<SparqlQueryGrain.SparqlState>(() => new SparqlQueryGrain.SparqlState());
+        var grain = new SparqlQueryGrain(persistence);
+
+        await grain.LoadRdfAsync(BuildingTurtle, "turtle", "t1");
+
+        var count = await grain.GetTripleCountAsync("t1");
+        count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ExecuteQueryAsync_FiltersByTenant()
+    {
+        var persistence = new TestPersistentState<SparqlQueryGrain.SparqlState>(() => new SparqlQueryGrain.SparqlState());
+        var grain = new SparqlQueryGrain(persistence);
+
+        await grain.LoadRdfAsync("@prefix brick: <https://brickschema.org/schema/Brick#> . <urn:tenant-a-building> a brick:Building .", "turtle", "tenant-a");
+        await grain.LoadRdfAsync("@prefix brick: <https://brickschema.org/schema/Brick#> . <urn:tenant-b-building> a brick:Building .", "turtle", "tenant-b");
+
+        var query = "SELECT ?s WHERE { ?s a <https://brickschema.org/schema/Brick#Building> }";
+        var tenantAResult = await grain.ExecuteQueryAsync(query, "tenant-a");
+        var tenantBResult = await grain.ExecuteQueryAsync(query, "tenant-b");
+
+        tenantAResult.Rows.Should().ContainSingle();
+        tenantAResult.Rows[0].Values["s"].Should().Be("urn:tenant-a-building");
+        tenantBResult.Rows.Should().ContainSingle();
+        tenantBResult.Rows[0].Values["s"].Should().Be("urn:tenant-b-building");
+    }
+
+    [Fact]
+    public async Task ExecuteQueryAsync_ReturnsBindings()
+    {
+        var persistence = new TestPersistentState<SparqlQueryGrain.SparqlState>(() => new SparqlQueryGrain.SparqlState());
+        var grain = new SparqlQueryGrain(persistence);
+
+        await grain.LoadRdfAsync(BuildingTurtle, "turtle", "t1");
+        var query = "SELECT ?s ?label WHERE { ?s <https://brickschema.org/schema/Brick#label> ?label }";
+
+        var result = await grain.ExecuteQueryAsync(query, "t1");
+
+        result.IsBooleanResult.Should().BeFalse();
+        result.Variables.Should().Contain(new[] { "s", "label" });
+        result.Rows.Should().ContainSingle();
+        result.Rows[0].Values["s"].Should().Be("urn:building1");
+        result.Rows[0].Values["label"].Should().Be("HQ");
+    }
+
+    [Fact]
+    public async Task ClearAsync_RemovesTenantTriples()
+    {
+        var persistence = new TestPersistentState<SparqlQueryGrain.SparqlState>(() => new SparqlQueryGrain.SparqlState());
+        var grain = new SparqlQueryGrain(persistence);
+
+        await grain.LoadRdfAsync(BuildingTurtle, "turtle", "t1");
+        await grain.ClearAsync("t1");
+
+        var count = await grain.GetTripleCountAsync("t1");
+        count.Should().Be(0);
+    }
+}

--- a/src/SiloHost/Program.cs
+++ b/src/SiloHost/Program.cs
@@ -154,6 +154,7 @@ internal static class Program
             siloBuilder.AddMemoryGrainStorage("GraphIndexStore");
             siloBuilder.AddMemoryGrainStorage("GraphTagIndexStore");
             siloBuilder.AddMemoryGrainStorage("GraphTenantStore");
+            siloBuilder.AddMemoryGrainStorage("SparqlStore");
             siloBuilder.AddMemoryStreams("DeviceUpdates");
             siloBuilder.AddMemoryGrainStorage("PointStore");
             siloBuilder.AddMemoryStreams("PointUpdates");

--- a/src/SiloHost/SiloHost.csproj
+++ b/src/SiloHost/SiloHost.csproj
@@ -6,6 +6,7 @@
     <PackageReference Include="Microsoft.Orleans.Clustering.AdoNet" Version="9.2.1" />
     <PackageReference Include="Microsoft.Orleans.Streaming" Version="9.2.1" />
     <PackageReference Include="Npgsql" Version="8.0.5" />
+    <PackageReference Include="dotNetRDF" Version="3.2.0" />
     <ProjectReference Include="../Grains.Abstractions/Grains.Abstractions.csproj" />
     <ProjectReference Include="../DataModel.Analyzer/DataModel.Analyzer.csproj" />
     <ProjectReference Include="../Telemetry.Ingest/Telemetry.Ingest.csproj" />

--- a/src/SiloHost/SparqlQueryGrain.cs
+++ b/src/SiloHost/SparqlQueryGrain.cs
@@ -1,0 +1,234 @@
+using Grains.Abstractions;
+using Orleans;
+using Orleans.Runtime;
+using VDS.RDF;
+using VDS.RDF.Parsing;
+using VDS.RDF.Query;
+
+namespace SiloHost;
+
+public sealed class SparqlQueryGrain : Grain, ISparqlQueryGrain
+{
+    private readonly IPersistentState<SparqlState> _state;
+
+    public SparqlQueryGrain([PersistentState("sparql-state", "SparqlStore")] IPersistentState<SparqlState> state)
+    {
+        _state = state;
+    }
+
+    public async Task LoadRdfAsync(string rdfContent, string format, string tenantId)
+    {
+        if (string.IsNullOrWhiteSpace(rdfContent))
+        {
+            throw new ArgumentException("RDF content must not be empty.", nameof(rdfContent));
+        }
+
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new ArgumentException("Tenant ID must not be empty.", nameof(tenantId));
+        }
+
+        var parser = CreateParser(format);
+        var graph = new Graph();
+        parser.Load(graph, new StringReader(rdfContent));
+
+        if (!_state.State.TenantTriples.TryGetValue(tenantId, out var tenantTriples))
+        {
+            tenantTriples = new List<SerializedTriple>();
+            _state.State.TenantTriples[tenantId] = tenantTriples;
+        }
+
+        foreach (var triple in graph.Triples)
+        {
+            tenantTriples.Add(SerializedTriple.FromTriple(triple));
+        }
+
+        await _state.WriteStateAsync();
+    }
+
+    public Task<SparqlQueryResult> ExecuteQueryAsync(string sparqlQuery, string tenantId)
+    {
+        if (string.IsNullOrWhiteSpace(sparqlQuery))
+        {
+            throw new ArgumentException("SPARQL query must not be empty.", nameof(sparqlQuery));
+        }
+
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new ArgumentException("Tenant ID must not be empty.", nameof(tenantId));
+        }
+
+        var graph = BuildGraphForTenant(tenantId);
+        var store = new TripleStore();
+        store.Add(graph);
+
+        var parser = new SparqlQueryParser();
+        var query = parser.ParseFromString(sparqlQuery);
+        var processor = new LeviathanQueryProcessor(store);
+        var result = processor.ProcessQuery(query);
+
+        if (result is SparqlResultSet resultSet)
+        {
+            var response = new SparqlQueryResult
+            {
+                IsBooleanResult = resultSet.ResultsType == SparqlResultsType.Boolean,
+                BooleanResult = resultSet.Result,
+                Variables = resultSet.Variables.ToList()
+            };
+
+            foreach (var row in resultSet)
+            {
+                var binding = new SparqlResultBinding();
+                foreach (var variable in resultSet.Variables)
+                {
+                    if (row.TryGetValue(variable, out var node) && node != null)
+                    {
+                        binding.Values[variable] = node is ILiteralNode literal ? literal.Value : node.ToString();
+                    }
+                }
+
+                response.Rows.Add(binding);
+            }
+
+            return Task.FromResult(response);
+        }
+
+        throw new InvalidOperationException("SPARQL query did not return a result set.");
+    }
+
+    public Task<int> GetTripleCountAsync(string tenantId)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new ArgumentException("Tenant ID must not be empty.", nameof(tenantId));
+        }
+
+        if (_state.State.TenantTriples.TryGetValue(tenantId, out var tenantTriples))
+        {
+            return Task.FromResult(tenantTriples.Count);
+        }
+
+        return Task.FromResult(0);
+    }
+
+    public async Task ClearAsync(string tenantId)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new ArgumentException("Tenant ID must not be empty.", nameof(tenantId));
+        }
+
+        if (_state.State.TenantTriples.Remove(tenantId))
+        {
+            await _state.WriteStateAsync();
+        }
+    }
+
+    private static IRdfReader CreateParser(string format)
+    {
+        return format.Trim().ToLowerInvariant() switch
+        {
+            "ttl" or "turtle" => new TurtleParser(),
+            "nt" or "ntriples" => new NTriplesParser(),
+            "rdfxml" or "xml" => new RdfXmlParser(),
+            _ => throw new ArgumentException($"Unsupported RDF format: {format}", nameof(format))
+        };
+    }
+
+    private Graph BuildGraphForTenant(string tenantId)
+    {
+        var graph = new Graph();
+        if (_state.State.TenantTriples.TryGetValue(tenantId, out var tenantTriples))
+        {
+            foreach (var triple in tenantTriples)
+            {
+                graph.Assert(triple.ToTriple(graph));
+            }
+        }
+
+        return graph;
+    }
+
+    [GenerateSerializer]
+    public sealed class SparqlState
+    {
+        [Id(0)] public Dictionary<string, List<SerializedTriple>> TenantTriples { get; set; } = new();
+    }
+
+    [GenerateSerializer]
+    public sealed class SerializedTriple
+    {
+        [Id(0)] public string Subject { get; set; } = string.Empty;
+        [Id(1)] public string Predicate { get; set; } = string.Empty;
+        [Id(2)] public string ObjectValue { get; set; } = string.Empty;
+        [Id(3)] public string ObjectNodeType { get; set; } = string.Empty;
+        [Id(4)] public string DataType { get; set; } = string.Empty;
+        [Id(5)] public string Language { get; set; } = string.Empty;
+
+        public static SerializedTriple FromTriple(Triple triple)
+        {
+            var serialized = new SerializedTriple
+            {
+                Subject = triple.Subject.ToString(),
+                Predicate = triple.Predicate.ToString(),
+                ObjectValue = triple.Object.ToString(),
+                ObjectNodeType = triple.Object.NodeType.ToString()
+            };
+
+            if (triple.Object is ILiteralNode literal)
+            {
+                serialized.DataType = literal.DataType?.ToString() ?? string.Empty;
+                serialized.Language = literal.Language ?? string.Empty;
+                serialized.ObjectValue = literal.Value;
+            }
+
+            return serialized;
+        }
+
+        public Triple ToTriple(IGraph graph)
+        {
+            var subjectNode = CreateSubjectNode(graph);
+            var predicateNode = graph.CreateUriNode(UriFactory.Create(Predicate));
+            var objectNode = CreateObjectNode(graph);
+            return new Triple(subjectNode, predicateNode, objectNode);
+        }
+
+        private INode CreateSubjectNode(IGraph graph)
+        {
+            if (Subject.StartsWith("_:", StringComparison.Ordinal))
+            {
+                return graph.CreateBlankNode(Subject[2..]);
+            }
+
+            return graph.CreateUriNode(UriFactory.Create(Subject));
+        }
+
+        private INode CreateObjectNode(IGraph graph)
+        {
+            if (ObjectNodeType.Equals(nameof(NodeType.Uri), StringComparison.Ordinal))
+            {
+                return graph.CreateUriNode(UriFactory.Create(ObjectValue));
+            }
+
+            if (ObjectNodeType.Equals(nameof(NodeType.Blank), StringComparison.Ordinal))
+            {
+                var blankNodeId = ObjectValue.StartsWith("_:", StringComparison.Ordinal)
+                    ? ObjectValue[2..]
+                    : ObjectValue;
+                return graph.CreateBlankNode(blankNodeId);
+            }
+
+            if (!string.IsNullOrEmpty(DataType))
+            {
+                return graph.CreateLiteralNode(ObjectValue, UriFactory.Create(DataType));
+            }
+
+            if (!string.IsNullOrEmpty(Language))
+            {
+                return graph.CreateLiteralNode(ObjectValue, Language);
+            }
+
+            return graph.CreateLiteralNode(ObjectValue);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide an embedded SPARQL query capability so RDF can be loaded and queried inside the silo with tenant isolation for later API/integration use. 
- Surface the new SPARQL functionality via the ApiGateway and document usage so developers can load RDF and run queries locally.

### Description

- Implemented `ISparqlQueryGrain` contract and DTOs in `src/Grains.Abstractions/SparqlContracts.cs` and added `SparqlQueryGrain` in `src/SiloHost/SparqlQueryGrain.cs` that parses RDF (Turtle/N-Triples/RDF-XML) using `dotNetRDF`, stores tenant-scoped serialized triples, builds an in-memory graph per tenant, executes SPARQL queries, counts triples, and clears tenant data. 
- Exposed SPARQL REST endpoints in `ApiGateway` by adding request/response DTOs (`src/ApiGateway/Sparql/*`) and route mappings in `src/ApiGateway/Program.cs` for `/api/sparql/load`, `/api/sparql/query`, and `/api/sparql/stats` with tenant resolution and authorization. 
- Added unit/integration tests: `SiloHost.Tests/SparqlQueryGrainTests.cs` (grain unit tests) and `ApiGateway.Tests/SparqlEndpointTests.cs` (API integration tests using a mocked cluster client). 
- Added documentation: `docs/sparql-query-service.md`, updated `docs/api-gateway-apis.md` and `README.md` to reference the new SPARQL docs and show API usage, and recorded the change in `plans.md` (Session 4). 
- Project changes: added `dotNetRDF` package to `src/SiloHost/SiloHost.csproj` and registered a memory grain storage `SparqlStore` in `src/SiloHost/Program.cs`.

### Testing

- Ran grain unit tests with `dotnet test src/SiloHost.Tests/SiloHost.Tests.csproj --filter FullyQualifiedName~SparqlQueryGrainTests`, which passed (4 passed, 0 failed). 
- Ran API tests with `dotnet test src/ApiGateway.Tests/ApiGateway.Tests.csproj --filter FullyQualifiedName~SparqlEndpointTests`, which passed (3 passed, 0 failed). 
- Performed a `dotnet build` as part of verification and observed a successful build (existing warnings only as noted in plans).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900a4217f48326b0f382e97669445d)