### PR TITLE
Raise telemetry query/export defaults for larger downloads

### DIFF
--- a/plans.md
+++ b/plans.md
@@ -4477,3 +4477,44 @@ GatewayId が命名ルールに従わないケースでも安全に遠隔制御�
 ## Retrospective
 - ルーティング根拠を「推測ルール」から「明示マップ中心」に寄せたことで、運用者が意図通りに制御先を管理しやすくなった。
 - 今後は Admin UI で JSON 直接編集だけでなく、行単位 CRUD にも拡張すると入力ミスを減らせる。
+
+---
+
+# plans.md: Telemetry取得上限の見直し（大きめエクスポート対応） (2026-02-15)
+
+## Purpose
+テレメトリ取得APIにおける既定上限（DefaultQueryLimit=1000 / MaxInlineRecords=1000）が小さく、URLダウンロード用途の実運用に不向きなため、既定値を引き上げて大きめのエクスポートを扱えるようにする。
+
+## Success Criteria
+1. `TelemetryStorageOptions.DefaultQueryLimit` の既定値が引き上げられている。
+2. `TelemetryExportOptions.MaxInlineRecords` の既定値が引き上げられている。
+3. `dotnet build` と `dotnet test` が成功する。
+
+## Steps
+1. 既定値を定義している箇所を特定する。
+2. 取得上限とインライン閾値を引き上げる。
+3. build/test を実行し、結果を記録する。
+
+## Progress
+- [x] Step 1: 既定値定義箇所の特定
+- [x] Step 2: 既定値引き上げ
+- [x] Step 3: build/test 実行
+
+## Observations
+- `DefaultQueryLimit` は API の limit 未指定時にエクスポート件数上限そのものとして効く。
+- `MaxInlineRecords` はインライン返却とURL返却の分岐にのみ影響する。
+
+## Decisions
+- URLダウンロード前提の実運用を想定し、既定値を次の通り引き上げる。
+  - `DefaultQueryLimit`: 1000 -> 100000
+  - `MaxInlineRecords`: 1000 -> 10000
+
+## Verification
+- `dotnet build`
+  - Result: Succeeded (0 errors, 既存 warning のみ)
+- `dotnet test`
+  - Result: Succeeded (Failed 0)
+
+## Retrospective
+- API limit 未指定時の取得上限を緩和でき、URLエクスポートを前提にしたユースケースへ寄せられた。
+- レコードサイズは可変のため、将来的には byte ベース上限（例: MaxExportBytes）を追加するとさらに運用しやすい。

--- a/src/ApiGateway/Telemetry/TelemetryExportOptions.cs
+++ b/src/ApiGateway/Telemetry/TelemetryExportOptions.cs
@@ -5,5 +5,5 @@ public sealed class TelemetryExportOptions
     public string ExportRoot { get; set; } = "storage/exports";
     public int DefaultTtlMinutes { get; set; } = 60;
     public int CleanupIntervalSeconds { get; set; } = 300;
-    public int MaxInlineRecords { get; set; } = 1000;
+    public int MaxInlineRecords { get; set; } = 10000;
 }

--- a/src/Telemetry.Storage/TelemetryStorageOptions.cs
+++ b/src/Telemetry.Storage/TelemetryStorageOptions.cs
@@ -12,5 +12,5 @@ public sealed class TelemetryStorageOptions
 
     public int CompactionIntervalSeconds { get; set; } = 300;
 
-    public int DefaultQueryLimit { get; set; } = 1000;
+    public int DefaultQueryLimit { get; set; } = 100000;
 }


### PR DESCRIPTION
### Motivation
- Increase defaults for telemetry retrieval so URL-based exports can produce much larger files (practical target ~100MB) and avoid premature export handoff while keeping API contracts unchanged.

### Description
- Bumped `TelemetryStorageOptions.DefaultQueryLimit` from `1000` to `100000` (`src/Telemetry.Storage/TelemetryStorageOptions.cs`) and `TelemetryExportOptions.MaxInlineRecords` from `1000` to `10000` (`src/ApiGateway/Telemetry/TelemetryExportOptions.cs`), and recorded the change in `plans.md`.

### Testing
- Ran `dotnet build` and `dotnet test` for the solution and all tests succeeded (build succeeded with existing warnings, `dotnet test` passed with 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991714d741c832686296cba92d457ed)