### PR TITLE
Use byte-based inline telemetry threshold and increase storage query default

### DIFF
--- a/src/ApiGateway.Tests/TelemetryInlineResponsePolicyTests.cs
+++ b/src/ApiGateway.Tests/TelemetryInlineResponsePolicyTests.cs
@@ -1,0 +1,64 @@
+using ApiGateway.Telemetry;
+using FluentAssertions;
+using Telemetry.Storage;
+using Xunit;
+
+namespace ApiGateway.Tests;
+
+public sealed class TelemetryInlineResponsePolicyTests
+{
+    [Fact]
+    public void ShouldReturnInline_WhenEstimatedPayloadIsWithinLimit_ReturnsTrue()
+    {
+        var options = new TelemetryExportOptions { MaxInlineBytes = 4096 };
+        var results = CreateResults(2, payloadSize: 100);
+
+        var actual = TelemetryInlineResponsePolicy.ShouldReturnInline(results, options);
+
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldReturnInline_WhenEstimatedPayloadExceedsLimit_ReturnsFalse()
+    {
+        var options = new TelemetryExportOptions { MaxInlineBytes = 1024 };
+        var results = CreateResults(5, payloadSize: 500);
+
+        var actual = TelemetryInlineResponsePolicy.ShouldReturnInline(results, options);
+
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldReturnInline_WhenMaxInlineBytesIsZero_UsesMinimumByteLimit()
+    {
+        var options = new TelemetryExportOptions { MaxInlineBytes = 0 };
+        var results = CreateResults(1, payloadSize: 100);
+
+        var actual = TelemetryInlineResponsePolicy.ShouldReturnInline(results, options);
+
+        actual.Should().BeFalse();
+    }
+
+    private static IReadOnlyList<TelemetryQueryResult> CreateResults(int count, int payloadSize)
+    {
+        var items = new List<TelemetryQueryResult>(count);
+        var payload = new string('x', payloadSize);
+        var now = DateTimeOffset.UtcNow;
+
+        for (var i = 0; i < count; i++)
+        {
+            items.Add(new TelemetryQueryResult(
+                "t1",
+                "d1",
+                $"p{i}",
+                now,
+                i,
+                payload,
+                payload,
+                null));
+        }
+
+        return items;
+    }
+}

--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -413,8 +413,7 @@ app.MapGet("/api/telemetry/{deviceId}", async (
         return Results.Ok(TelemetryQueryResponse.Inline(results));
     }
 
-    var maxInline = Math.Max(1, exportOptions.Value.MaxInlineRecords);
-    if (results.Count <= maxInline)
+    if (TelemetryInlineResponsePolicy.ShouldReturnInline(results, exportOptions.Value))
     {
         return Results.Ok(TelemetryQueryResponse.Inline(results));
     }

--- a/src/ApiGateway/Telemetry/TelemetryExportOptions.cs
+++ b/src/ApiGateway/Telemetry/TelemetryExportOptions.cs
@@ -5,5 +5,5 @@ public sealed class TelemetryExportOptions
     public string ExportRoot { get; set; } = "storage/exports";
     public int DefaultTtlMinutes { get; set; } = 60;
     public int CleanupIntervalSeconds { get; set; } = 300;
-    public int MaxInlineRecords { get; set; } = 1000;
+    public int MaxInlineBytes { get; set; } = 5 * 1024 * 1024;
 }

--- a/src/ApiGateway/Telemetry/TelemetryInlineResponsePolicy.cs
+++ b/src/ApiGateway/Telemetry/TelemetryInlineResponsePolicy.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using Telemetry.Storage;
+
+namespace ApiGateway.Telemetry;
+
+public static class TelemetryInlineResponsePolicy
+{
+    public static bool ShouldReturnInline(IReadOnlyList<TelemetryQueryResult> results, TelemetryExportOptions options)
+    {
+        if (results.Count == 0)
+        {
+            return true;
+        }
+
+        var maxInlineBytes = Math.Max(1, options.MaxInlineBytes);
+        return EstimateInlineBytes(results) <= maxInlineBytes;
+    }
+
+    internal static int EstimateInlineBytes(IReadOnlyList<TelemetryQueryResult> results)
+    {
+        var response = TelemetryQueryResponse.Inline(results);
+        return JsonSerializer.SerializeToUtf8Bytes(response).Length;
+    }
+}

--- a/src/Telemetry.Storage/TelemetryStorageOptions.cs
+++ b/src/Telemetry.Storage/TelemetryStorageOptions.cs
@@ -12,5 +12,5 @@ public sealed class TelemetryStorageOptions
 
     public int CompactionIntervalSeconds { get; set; } = 300;
 
-    public int DefaultQueryLimit { get; set; } = 1000;
+    public int DefaultQueryLimit { get; set; } = 100000;
 }


### PR DESCRIPTION
### Motivation
- The previous inline/export decision used a record-count threshold which doesn't reflect variable per-record payload sizes and was reported insufficient for large downloads.  
- The telemetry query default limit was also considered too small for URL-based exports and should be raised to support larger exports.

### Description
- Replaced record-count gating with a byte-based policy by adding `TelemetryInlineResponsePolicy` that estimates UTF-8 payload size of `TelemetryQueryResponse.Inline(results)` and decides inline vs URL export. (`src/ApiGateway/Telemetry/TelemetryInlineResponsePolicy.cs`)  
- Added `MaxInlineBytes` to `TelemetryExportOptions` with a default of `5 * 1024 * 1024` (5MB) and removed the record-count option usage. (`src/ApiGateway/Telemetry/TelemetryExportOptions.cs`)  
- Updated `/api/telemetry/{deviceId}` endpoint to use `TelemetryInlineResponsePolicy.ShouldReturnInline(...)` instead of `MaxInlineRecords`. (`src/ApiGateway/Program.cs`)  
- Increased `TelemetryStorageOptions.DefaultQueryLimit` from `1000` to `100000` to allow larger query/export sizes. (`src/Telemetry.Storage/TelemetryStorageOptions.cs`)  
- Added unit tests `TelemetryInlineResponsePolicyTests` to validate under-limit, over-limit, and zero-limit behavior and updated `plans.md` with intent and verification notes. (`src/ApiGateway.Tests/TelemetryInlineResponsePolicyTests.cs`, `plans.md`) 

### Testing
- Ran `dotnet build` for the solution and the build succeeded (only existing warnings reported).  
- Ran `dotnet test` and all test projects passed (no failures); new `TelemetryInlineResponsePolicyTests` executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991714d741c832686296cba92d457ed)